### PR TITLE
Adding devcontainer for vscode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,36 @@
+FROM ruby:2.6
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+ARG GO_VERSION=1.14.3
+ENV GOROOT=/usr/local/go
+
+RUN wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
+    && tar -xvf go${GO_VERSION}.linux-amd64.tar.gz \
+    && mv go /usr/local \
+    && rm go${GO_VERSION}.linux-amd64.tar.gz
+
+RUN export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    && apt-get -y install git openssh-client less iproute2 procps lsb-release libsodium-dev mariadb-client \
+    && gem install bundler \
+    && gem install ruby-debug-ide \
+    && gem install debase \
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV DEBIAN_FRONTEND=dialog
+
+RUN echo "export PATH=${GOROOT}/bin:${PATH}" >> /root/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+	"name": "Ruby, Go, and MySQL",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace",
+
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	"extensions": [
+		"rebornix.Ruby"
+	],
+
+	"postCreateCommand": "export PATH=/usr/local/go/bin:$PATH && bundle install",
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3'
+
+services:
+  app:
+    build: 
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached   
+    command: sleep infinity
+    ports: 
+      - 6011:6011
+    links: 
+      - db
+    environment: 
+      DB_USER: test
+      DB_PASS: password
+      DB_HOST: db
+      DB_NAME: test
+      DB_PORT: 3306
+      ECDSA_KEY: 30770201010420a6885a310b694b7bb4ba985459de1e79446dddcd1247c62ece925402b362a110a00a06082a8648ce3d030107a1440342000403eb64f714c4b4ed394331c26c31b7ce7156d00fb28982ad2679a87eaa1a3869802fbeb1d7ee28002762921929c3f7603672d535fcac3d24d57afbb4e2d97f5a
+      KEY_CLAIM_TOKEN: thisisatoken=302
+      RETRIEVE_HMAC_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    
+  db:
+    image: mysql:5.7
+    restart: unless-stopped
+    ports: 
+      - 3310:3306
+    environment:
+      MYSQL_DATABASE: test
+      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_USER: test


### PR DESCRIPTION
Closes #6. Adds a devcontainer configuration for vscode.

Once in the dev container, run `make test` to show Ruby tests running against the Go server. The mysql server is exposed locally on port 3310 if you would like to inspect it with common tools.