### PR TITLE
Set default aws region and credentials before login

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -11,6 +11,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1


### PR DESCRIPTION
Follow up to #20 

The AWS Login step in GithubAction `dockerhub.yml` failed on that previous PR because a default region was not configured. Following [these instructions](https://github.com/aws-actions/amazon-ecr-login#credentials-and-region), this adds a step before login to specify the AWS credentials and a default region.