### PR TITLE
Add HTTPS

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Check For New Deployments
         env:
           GITHUB_SHA: ${{ github.sha }}
-          RETRIEVAL_URL: retrieval.${{ secrets.TF_VAR_route53_zone_name }}
-          SUBMISSION_URL: submission.${{ secrets.TF_VAR_route53_zone_name }}
+          RETRIEVAL_URL: https://retrieval.${{ secrets.TF_VAR_route53_zone_name }}
+          SUBMISSION_URL: https://submission.${{ secrets.TF_VAR_route53_zone_name }}
         run: |
           count=0
           kr_finished=0


### PR DESCRIPTION
The deploy script checks the current version of the deployed container using a curl request. The URL for that curl request was missing HTTPS and therefore failed.