### PR TITLE
Fix dev container configuration

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,7 +9,8 @@ services:
       - ..:/workspace:cached   
     command: sleep infinity
     ports: 
-      - 6011:6011
+      - 8000:8000
+      - 8001:8001
     links: 
       - db
     environment: 
@@ -18,6 +19,7 @@ services:
       DB_HOST: db
       DB_NAME: test
       DB_PORT: 3306
+      DATABASE_URL: "test:password@tcp(db)/test"
       ECDSA_KEY: 30770201010420a6885a310b694b7bb4ba985459de1e79446dddcd1247c62ece925402b362a110a00a06082a8648ce3d030107a1440342000403eb64f714c4b4ed394331c26c31b7ce7156d00fb28982ad2679a87eaa1a3869802fbeb1d7ee28002762921929c3f7603672d535fcac3d24d57afbb4e2d97f5a
       KEY_CLAIM_TOKEN: thisisatoken=302
       RETRIEVE_HMAC_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
Fixes #25.

Previous to this PR the work done in the development container was not exposed to the host. This allows external applications like the mobile app or the playground to connect to the services running inside the dev container. Additionally, one still needed to set the `DATABASE_URL` before running the servers. This is now automatically configured.