### PR TITLE
Added Synk GitHub action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -11,4 +11,4 @@ jobs:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
         command: monitor
-        args: --file=go.mod --org=cds-snc --project-name=covid-shield-server
+        args: --file=go.mod --org=exposurenotification --project-name=covid-shield-server


### PR DESCRIPTION
Enhancement to #13. The out-of-box integration only picks up the Ruby integration, not the Go packages. Using a GitHub action we can monitor the go packages through the CLI.