### PR TITLE
Added Terraform for metric and tracer provider

### DIFF
--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -43,6 +43,7 @@ data "template_file" "covidshield_key_retrieval_task" {
     ecdsa_key             = aws_secretsmanager_secret_version.key_retrieval_env_ecdsa_key.arn
     database_url          = aws_secretsmanager_secret_version.server_database_url.arn
     metric_provider       = var.metric_provider
+    tracer_provider       = var.tracer_provider
   }
 }
 
@@ -119,6 +120,7 @@ data "template_file" "covidshield_key_submission_task" {
     key_claim_token       = aws_secretsmanager_secret_version.key_submission_env_key_claim_token.arn
     database_url          = aws_secretsmanager_secret_version.server_database_url.arn
     metric_provider       = var.metric_provider
+    tracer_provider       = var.tracer_provider
   }
 }
 

--- a/config/terraform/aws/task-definitions/covidshield_key_retrieval.json
+++ b/config/terraform/aws/task-definitions/covidshield_key_retrieval.json
@@ -24,6 +24,10 @@
         {
             "name": "METRIC_PROVIDER",
             "value": "${metric_provider}"
+        },
+        {
+          "name": "TRACER_PROVIDER",
+          "value": "${tracer_provider}"
         }
       ],
       "secrets": [

--- a/config/terraform/aws/task-definitions/covidshield_key_submission.json
+++ b/config/terraform/aws/task-definitions/covidshield_key_submission.json
@@ -31,6 +31,10 @@
         {
             "name": "METRIC_PROVIDER",
             "value": "${metric_provider}"
+        },
+        {
+          "name": "TRACER_PROVIDER",
+          "value": "${tracer_provider}"
         }
       ],
       "secrets": [

--- a/config/terraform/aws/variables.auto.tfvars
+++ b/config/terraform/aws/variables.auto.tfvars
@@ -19,6 +19,7 @@ cloudwatch_log_group_name = "CovidShield"
 
 ecs_name        = "CovidShield"
 metric_provider = "stdout"
+tracer_provider = "stdout"
 
 # Key Retrieval
 ecs_key_retrieval_name = "KeyRetrieval"

--- a/config/terraform/aws/variables.tf
+++ b/config/terraform/aws/variables.tf
@@ -59,6 +59,11 @@ variable "metric_provider" {
   type = string
 }
 
+# Tracing provider
+variable "tracer_provider" {
+  type = string
+}
+
 ###
 # AWS VPC - networking.tf
 ###


### PR DESCRIPTION
Makes use of the new `METRIC_PROVIDER` and `TRACER_PROVIDER`  environment variables. Will log metrics in JSON format to stdout, where another application will be able to ingress them for metrics parsing.