### PR TITLE
consolidate endpoint fqdns

### DIFF
--- a/config/terraform/aws/certificates.tf
+++ b/config/terraform/aws/certificates.tf
@@ -1,7 +1,10 @@
-resource "aws_acm_certificate" "covidshield" {
-  domain_name               = var.route53_zone_name
-  subject_alternative_names = ["*.${var.route53_zone_name}"]
-  validation_method         = "DNS"
+resource "aws_acm_certificate" "submission_covidshield" {
+  domain_name = "submission.${var.route53_zone_name}"
+  subject_alternative_names = [
+    "retrieval.${var.route53_zone_name}",
+    var.route53_zone_name
+  ]
+  validation_method = "DNS"
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
@@ -15,10 +18,11 @@ resource "aws_acm_certificate" "covidshield" {
 ###
 # Cloudfront requires client certificate to be created in us-east-1
 ###
-resource "aws_acm_certificate" "retrieval_covidshield" {
-  provider          = aws.us-east-1
-  domain_name       = "retrieval.${var.route53_zone_name}"
-  validation_method = "DNS"
+resource "aws_acm_certificate" "covidshield" {
+  provider                  = aws.us-east-1
+  domain_name               = var.route53_zone_name
+  subject_alternative_names = ["*.${var.route53_zone_name}"]
+  validation_method         = "DNS"
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
@@ -27,35 +31,69 @@ resource "aws_acm_certificate" "retrieval_covidshield" {
   lifecycle {
     create_before_destroy = true
   }
+
+}
+
+resource "aws_route53_record" "submission_covidshield_certificate_validation" {
+  zone_id         = aws_route53_zone.covidshield.zone_id
+  allow_overwrite = true
+  name            = aws_acm_certificate.submission_covidshield.domain_validation_options.0.resource_record_name
+  type            = aws_acm_certificate.submission_covidshield.domain_validation_options.0.resource_record_type
+  records         = [aws_acm_certificate.submission_covidshield.domain_validation_options.0.resource_record_value]
+  ttl             = 60
+}
+
+resource "aws_route53_record" "submission_covidshield_certificate_validation_alt1" {
+  zone_id         = aws_route53_zone.covidshield.zone_id
+  allow_overwrite = true
+  name            = aws_acm_certificate.submission_covidshield.domain_validation_options.1.resource_record_name
+  type            = aws_acm_certificate.submission_covidshield.domain_validation_options.1.resource_record_type
+  records         = [aws_acm_certificate.submission_covidshield.domain_validation_options.1.resource_record_value]
+  ttl             = 60
+}
+
+resource "aws_route53_record" "submission_covidshield_certificate_validation_alt2" {
+  zone_id         = aws_route53_zone.covidshield.zone_id
+  allow_overwrite = true
+  name            = aws_acm_certificate.submission_covidshield.domain_validation_options.2.resource_record_name
+  type            = aws_acm_certificate.submission_covidshield.domain_validation_options.2.resource_record_type
+  records         = [aws_acm_certificate.submission_covidshield.domain_validation_options.2.resource_record_value]
+  ttl             = 60
 }
 
 resource "aws_route53_record" "covidshield_certificate_validation" {
-  zone_id = aws_route53_zone.covidshield.zone_id
-  name    = aws_acm_certificate.covidshield.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.covidshield.domain_validation_options.0.resource_record_type
-  records = [aws_acm_certificate.covidshield.domain_validation_options.0.resource_record_value]
-  ttl     = 60
+  provider        = aws.us-east-1
+  allow_overwrite = true
+  zone_id         = aws_route53_zone.covidshield.zone_id
+  name            = aws_acm_certificate.covidshield.domain_validation_options.0.resource_record_name
+  type            = aws_acm_certificate.covidshield.domain_validation_options.0.resource_record_type
+  records         = [aws_acm_certificate.covidshield.domain_validation_options.0.resource_record_value]
+  ttl             = 60
 }
 
-resource "aws_route53_record" "retrieval_covidshield_certificate_validation" {
-  zone_id = aws_route53_zone.covidshield.zone_id
-  name    = aws_acm_certificate.retrieval_covidshield.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.retrieval_covidshield.domain_validation_options.0.resource_record_type
-  records = [aws_acm_certificate.retrieval_covidshield.domain_validation_options.0.resource_record_value]
-  ttl     = 60
+resource "aws_route53_record" "wildcard_covidshield_certificate_validation" {
+  zone_id         = aws_route53_zone.covidshield.zone_id
+  allow_overwrite = true
+  name            = aws_acm_certificate.covidshield.domain_validation_options.1.resource_record_name
+  type            = aws_acm_certificate.covidshield.domain_validation_options.1.resource_record_type
+  records         = [aws_acm_certificate.covidshield.domain_validation_options.1.resource_record_value]
+  ttl             = 60
 }
 
-resource "aws_acm_certificate_validation" "covidshield" {
-  certificate_arn = aws_acm_certificate.covidshield.arn
+resource "aws_acm_certificate_validation" "submission_covidshield" {
+  certificate_arn = aws_acm_certificate.submission_covidshield.arn
   validation_record_fqdns = [
-    aws_route53_record.covidshield_certificate_validation.fqdn
+    aws_route53_record.submission_covidshield_certificate_validation.fqdn,
+    aws_route53_record.submission_covidshield_certificate_validation_alt1.fqdn,
+    aws_route53_record.submission_covidshield_certificate_validation_alt2.fqdn,
   ]
 }
 
-resource "aws_acm_certificate_validation" "retrieval_covidshield" {
+resource "aws_acm_certificate_validation" "covidshield" {
   provider        = aws.us-east-1
-  certificate_arn = aws_acm_certificate.retrieval_covidshield.arn
+  certificate_arn = aws_acm_certificate.covidshield.arn
   validation_record_fqdns = [
-    aws_route53_record.retrieval_covidshield_certificate_validation.fqdn
+    aws_route53_record.covidshield_certificate_validation.fqdn,
+    aws_route53_record.wildcard_covidshield_certificate_validation.fqdn,
   ]
 }

--- a/config/terraform/aws/cloudwatch.tf
+++ b/config/terraform/aws/cloudwatch.tf
@@ -1,7 +1,6 @@
 resource "aws_cloudwatch_log_group" "covidshield" {
-  name              = var.cloudwatch_log_group_name
-  kms_key_id        = aws_kms_key.cw.arn
-  retention_in_days = 365
+  name       = var.cloudwatch_log_group_name
+  kms_key_id = aws_kms_key.cw.arn
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
@@ -264,29 +263,11 @@ resource "aws_cloudwatch_metric_alarm" "ddos_detected_submission" {
   period              = "60"
   statistic           = "Sum"
   threshold           = "1"
-  alarm_description   = "This metric monitors for DDoS detected on submission ALB"
+  alarm_description   = "This metric monitors for DDoS detected on server ALB"
 
   alarm_actions = [aws_sns_topic.alert_warning.arn, aws_sns_topic.alert_critical.arn]
 
   dimensions = {
-    ResourceArn = aws_lb.covidshield_key_submission.arn
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "ddos_detected_retrieval" {
-  alarm_name          = "DDoSDetectedRetrievalALB"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "DDoSDetected"
-  namespace           = "AWS/DDoSProtection"
-  period              = "60"
-  statistic           = "Sum"
-  threshold           = "1"
-  alarm_description   = "This metric monitors for DDoS detected on retrieval ALB"
-
-  alarm_actions = [aws_sns_topic.alert_warning.arn, aws_sns_topic.alert_critical.arn]
-
-  dimensions = {
-    ResourceArn = aws_lb.covidshield_key_retrieval.arn
+    ResourceArn = aws_lb.covidshield_key_server.arn
   }
 }

--- a/config/terraform/aws/codedeploy.tf
+++ b/config/terraform/aws/codedeploy.tf
@@ -5,9 +5,9 @@ module "covid-shield-retrieval" {
   termination_wait_time_in_minutes = var.termination_wait_time_in_minutes
   cluster_name                     = aws_ecs_cluster.covidshield.name
   ecs_service_name                 = aws_ecs_service.covidshield_key_retrieval.name
-  lb_listener_arns                 = [aws_lb_listener.covidshield_key_retrieval.arn]
-  aws_lb_target_group_blue_name    = aws_lb_target_group.covidshield_key_retrieval.name
-  aws_lb_target_group_green_name   = aws_lb_target_group.covidshield_key_retrieval_2.name
+  lb_listener_arns                 = [aws_lb_listener.covidshield_key_server.arn]
+  aws_lb_target_group_blue_name    = aws_lb_target_group.covidshield_key_retrieval_blue.name
+  aws_lb_target_group_green_name   = aws_lb_target_group.covidshield_key_retrieval_green.name
 }
 
 module "covid-shield-submission" {
@@ -17,7 +17,7 @@ module "covid-shield-submission" {
   termination_wait_time_in_minutes = var.termination_wait_time_in_minutes
   cluster_name                     = aws_ecs_cluster.covidshield.name
   ecs_service_name                 = aws_ecs_service.covidshield_key_submission.name
-  lb_listener_arns                 = [aws_lb_listener.covidshield_key_submission.arn]
-  aws_lb_target_group_blue_name    = aws_lb_target_group.covidshield_key_submission.name
-  aws_lb_target_group_green_name   = aws_lb_target_group.covidshield_key_submission_2.name
+  lb_listener_arns                 = [aws_lb_listener.covidshield_key_server.arn]
+  aws_lb_target_group_blue_name    = aws_lb_target_group.covidshield_key_submission_blue.name
+  aws_lb_target_group_green_name   = aws_lb_target_group.covidshield_key_submission_green.name
 }

--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -62,7 +62,7 @@ resource "aws_ecs_task_definition" "covidshield_key_retrieval" {
 
 resource "aws_ecs_service" "covidshield_key_retrieval" {
   depends_on = [
-    aws_lb_listener.covidshield_key_retrieval,
+    aws_lb_listener.covidshield_key_server,
   ]
 
   name             = var.ecs_key_retrieval_name
@@ -90,7 +90,7 @@ resource "aws_ecs_service" "covidshield_key_retrieval" {
   }
 
   load_balancer {
-    target_group_arn = aws_lb_target_group.covidshield_key_retrieval.arn
+    target_group_arn = aws_lb_target_group.covidshield_key_retrieval_blue.arn
     container_name   = "key-retrieval"
     container_port   = 8001
   }
@@ -194,7 +194,7 @@ resource "aws_ecs_task_definition" "covidshield_key_submission" {
 
 resource "aws_ecs_service" "covidshield_key_submission" {
   depends_on = [
-    aws_lb_listener.covidshield_key_submission,
+    aws_lb_listener.covidshield_key_server,
   ]
 
   name             = var.ecs_key_submission_name
@@ -222,7 +222,7 @@ resource "aws_ecs_service" "covidshield_key_submission" {
   }
 
   load_balancer {
-    target_group_arn = aws_lb_target_group.covidshield_key_submission.arn
+    target_group_arn = aws_lb_target_group.covidshield_key_submission_blue.arn
     container_name   = "key-submission"
     container_port   = 8000
   }
@@ -239,6 +239,7 @@ resource "aws_ecs_service" "covidshield_key_submission" {
     ]
   }
 }
+
 resource "aws_appautoscaling_target" "submission" {
   count              = var.submission_autoscale_enabled ? 1 : 0
   service_namespace  = "ecs"
@@ -247,6 +248,7 @@ resource "aws_appautoscaling_target" "submission" {
   min_capacity       = var.min_capacity
   max_capacity       = var.max_capacity
 }
+
 resource "aws_appautoscaling_policy" "submission_cpu" {
   count              = var.submission_autoscale_enabled ? 1 : 0
   name               = "submission_cpu"

--- a/config/terraform/aws/outputs.tf
+++ b/config/terraform/aws/outputs.tf
@@ -29,7 +29,3 @@ output "security_group_load_balancer" {
 output "aws_db_subnet_group" {
   value = aws_db_subnet_group.covidshield
 }
-
-output "route53_submission_fqdn" {
-  value = aws_route53_record.covidshield_key_submission
-}

--- a/config/terraform/aws/shield.tf
+++ b/config/terraform/aws/shield.tf
@@ -1,22 +1,18 @@
 # Enable shield on cloudfront distribution
 resource "aws_shield_protection" "key_retrieval_distribution" {
   name         = "key_retrieval_distribution"
-  resource_arn = aws_cloudfront_distribution.key_retrieval_distribution.arn
+  resource_arn = aws_cloudfront_distribution.key_server_distribution.arn
 }
 
 # Enable shield on Route53 hosted zone
 resource "aws_shield_protection" "route53_covidshield" {
-  name         = "route53_covidshield"
+  name = "route53_covidshield"
+  //   resource_arn = aws_route53_zone.covidshield.arn
   resource_arn = "arn:aws:route53:::hostedzone/${aws_route53_zone.covidshield.zone_id}"
 }
 
 # Enable shield on ALBs
-resource "aws_shield_protection" "alb_covidshield_key_retrieval" {
-  name         = "alb_covidshield_key_retrieval"
-  resource_arn = aws_lb.covidshield_key_retrieval.arn
-}
-
-resource "aws_shield_protection" "alb_covidshield_key_submission" {
-  name         = "alb_covidshield_key_submission"
-  resource_arn = aws_lb.covidshield_key_submission.arn
+resource "aws_shield_protection" "alb_covidshield_key_server" {
+  name         = "alb_covidshield_key_server"
+  resource_arn = aws_lb.covidshield_key_server.arn
 }

--- a/config/terraform/aws/waf.tf
+++ b/config/terraform/aws/waf.tf
@@ -368,14 +368,9 @@ resource "aws_wafv2_web_acl" "key_retrieval_cdn" {
 ###
 # AWS WAF - Resource Assocation
 ###
-resource "aws_wafv2_web_acl_association" "key_submission_assocation" {
-  resource_arn = aws_lb.covidshield_key_submission.arn
+resource "aws_wafv2_web_acl_association" "key_server_assocation" {
+  resource_arn = aws_lb.covidshield_key_server.arn
   web_acl_arn  = aws_wafv2_web_acl.key_submission.arn
-}
-
-resource "aws_wafv2_web_acl_association" "key_retrieval_assocation" {
-  resource_arn = aws_lb.covidshield_key_retrieval.arn
-  web_acl_arn  = aws_wafv2_web_acl.key_retrieval.arn
 }
 
 ###


### PR DESCRIPTION
- consolidates submission/retrieval endpoints into a single endpoint
- all traffic passes through cloudfront first
- accepts submission/retrieval endpoints for transition purposes