### PR TITLE
Remove header from logging

### DIFF
--- a/pkg/server/keyclaim.go
+++ b/pkg/server/keyclaim.go
@@ -66,7 +66,7 @@ func (s *keyClaimServlet) newKeyClaim(w http.ResponseWriter, r *http.Request) {
 
 	keyClaim, err := s.db.NewKeyClaim(region, originator, hashID)
 	if err == persistence.ErrHashIDClaimed {
-		log(ctx, err).WithField("header", hdr).Info("hashID used")
+		log(ctx, err).Info("hashID used")
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	} else if err != nil {


### PR DESCRIPTION
When the code determined a Hash ID was used, the code would log the entire header including the bearer token, this could have led to a disclosure of the Bearer tokens through logs.