### PR TITLE
add validation on test listener before shifting prod traffic

### DIFF
--- a/.github/workflows/deploy-containers.yml
+++ b/.github/workflows/deploy-containers.yml
@@ -68,7 +68,8 @@ jobs:
           CONTAINER_PORT=`jq '.containerDefinitions[0].portMappings[0].containerPort' task-definition-retrieval.json`
           CONTAINER_NAME=${{ steps.download-taskdef-retrieval.outputs.container_name }}
           TASKDEF_ARN=`jq -r '.taskDefinitionArn' task-definition-retrieval.json | cut -f 1-6 -d "/"`
-          jq  --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port ' config/infrastructure/aws/appspec-template.json > covidshield-retrieval-appspec.json
+          LAMBDA='RetrievalValidateBeforeTraffic'
+          jq  --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" --arg lambda "$LAMBDA" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port | .Hooks[0].BeforeAllowTraffic = $lambda ' config/infrastructure/aws/appspec-template.json > covidshield-retrieval-appspec.json
 
       - name: Deploy image for retrieval service
         timeout-minutes: 10
@@ -143,7 +144,8 @@ jobs:
           CONTAINER_PORT=`jq '.containerDefinitions[0].portMappings[0].containerPort' task-definition-submission.json`
           CONTAINER_NAME=${{ steps.download-taskdef-submission.outputs.container_name }}
           TASKDEF_ARN=`jq -r '.taskDefinitionArn' task-definition-submission.json | cut -f 1-6 -d "/"`
-          jq  --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port ' config/infrastructure/aws/appspec-template.json > covidshield-submission-appspec.json
+          LAMBDA='SubmissionValidateBeforeTraffic'
+          jq  --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port | .Hooks[0].BeforeAllowTraffic = $lambda ' config/infrastructure/aws/appspec-template.json > covidshield-submission-appspec.json
 
       - name: Deploy image for submission service
         timeout-minutes: 10

--- a/config/infrastructure/aws/appspec-template.json
+++ b/config/infrastructure/aws/appspec-template.json
@@ -14,5 +14,10 @@
                 }
             }
         }
-    ]
+    ],
+	"Hooks": [
+		{
+			"BeforeAllowTraffic": "placeholder"
+		}
+	]    
 }

--- a/config/terraform/aws/codedeploy.tf
+++ b/config/terraform/aws/codedeploy.tf
@@ -23,3 +23,49 @@ module "covid-shield-submission" {
   aws_lb_target_group_blue_name    = aws_lb_target_group.covidshield_key_submission.name
   aws_lb_target_group_green_name   = aws_lb_target_group.covidshield_key_submission_2.name
 }
+
+###
+# AWS Lambda - Validate Deploy
+###
+data "archive_file" "lambda_validate_deploy" {
+  type        = "zip"
+  source_file = "lambda/lambda_validate_deploy.rb"
+  output_path = "/tmp/lambda_validate_deploy.rb.zip"
+}
+
+resource "aws_lambda_function" "retrieval_lambda_validate_deploy" {
+  filename      = "/tmp/lambda_validate_deploy.rb.zip"
+  function_name = "RetrievalValidateBeforeTraffic"
+  role          = aws_iam_role.lambda_validate_deploy.arn
+  handler       = "lambda_validate_deploy.handler"
+
+  source_code_hash = data.archive_file.lambda_validate_deploy.output_base64sha256
+
+  runtime = "ruby2.7"
+
+  environment {
+    variables = {
+      TEST_LB_ENDPOINT         = "https://${aws_lb.covidshield_key_retrieval.dns_name}:8443/services/ping"
+      CLOUDFRONT_CUSTOM_HEADER = var.cloudfront_custom_header
+    }
+  }
+
+}
+
+resource "aws_lambda_function" "submission_lambda_validate_deploy" {
+  filename      = "/tmp/lambda_validate_deploy.rb.zip"
+  function_name = "SubmissionValidateBeforeTraffic"
+  role          = aws_iam_role.lambda_validate_deploy.arn
+  handler       = "lambda_validate_deploy.handler"
+
+  source_code_hash = data.archive_file.lambda_validate_deploy.output_base64sha256
+
+  runtime = "ruby2.7"
+
+  environment {
+    variables = {
+      TEST_LB_ENDPOINT = "https://${aws_lb.covidshield_key_submission.dns_name}:8443/services/ping"
+    }
+  }
+
+}

--- a/config/terraform/aws/lambda/lambda_validate_deploy.rb
+++ b/config/terraform/aws/lambda/lambda_validate_deploy.rb
@@ -1,0 +1,44 @@
+require 'net/http'
+require 'aws-sdk-codedeploy'
+
+def handler(event:, context:)
+  logger = Logger.new($stdout)
+  uri = URI.parse(ENV['TEST_LB_ENDPOINT'])
+
+  def codedeploy_status(status, event)
+    client = Aws::CodeDeploy::Client.new
+    client.put_lifecycle_event_hook_execution_status(
+      deployment_id: event['DeploymentId'],
+      lifecycle_event_hook_execution_id: event['LifecycleEventHookExecutionId'],
+      status: status
+    )
+  end
+
+  begin
+    resp = Net::HTTP.start(
+      uri.host,
+      uri.port,
+      use_ssl: true, open_timeout: 5,
+      read_timeout: 5,
+      verify_mode: OpenSSL::SSL::VERIFY_NONE
+    ) do |http|
+      request = Net::HTTP::Get.new uri
+      request['covidshield'] = ENV['CLOUDFRONT_CUSTOM_HEADER'] if ENV['CLOUDFRONT_CUSTOM_HEADER']
+      response = http.request request
+    end
+  rescue StandardError => error
+    status = 'Failed'
+    codedeploy_status(status, event)
+    logger.info("Validation of test listener failed with error: #{error.message}")
+  end
+
+  if resp && resp.code == '200' && resp.body.start_with?('OK')
+    status = 'Succeeded'
+    codedeploy_status(status, event)
+    logger.info("Validation of test listener status code #{status}: #{resp}")
+  else
+    status = 'Failed'
+    codedeploy_status(status, event)
+    logger.info("Validation of test listener status code #{status}: #{resp}")
+  end
+end

--- a/config/terraform/aws/networking.tf
+++ b/config/terraform/aws/networking.tf
@@ -296,6 +296,13 @@ resource "aws_security_group" "covidshield_load_balancer" {
     cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:AWS008
   }
 
+  ingress {
+    protocol    = "tcp"
+    from_port   = 8443
+    to_port     = 8443
+    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:AWS008
+  }
+
   egress {
     protocol    = "tcp"
     from_port   = 8001


### PR DESCRIPTION
Leverage CodeDeploy validation hooks to test new deployments before shifting production traffic to new deployment.