### PR TITLE
Creates KMS in US-East and uses it for SNS

### DIFF
--- a/config/terraform/aws/kms.tf
+++ b/config/terraform/aws/kms.tf
@@ -48,7 +48,7 @@ EOF
 }
 
 resource "aws_kms_key" "cw_us_east" {
-  provider          = aws.us-east-1
+  provider = aws.us-east-1
 
   description         = "CloudWatch Log Group Key"
   enable_key_rotation = true

--- a/config/terraform/aws/kms.tf
+++ b/config/terraform/aws/kms.tf
@@ -46,3 +46,52 @@ resource "aws_kms_key" "cw" {
 }
 EOF
 }
+
+resource "aws_kms_key" "cw_us_east" {
+  provider          = aws.us-east-1
+
+  description         = "CloudWatch Log Group Key"
+  enable_key_rotation = true
+
+  policy = <<EOF
+{
+  "Version" : "2012-10-17",
+  "Id" : "key-default-1",
+  "Statement" : [ {
+      "Sid" : "Enable IAM User Permissions",
+      "Effect" : "Allow",
+      "Principal" : {
+        "AWS" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      },
+      "Action" : "kms:*",
+      "Resource" : "*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": { "Service": "logs.us-east-1.amazonaws.com" },
+      "Action": [ 
+        "kms:Encrypt*",
+        "kms:Decrypt*",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:Describe*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Allow_CloudWatch_for_CMK",
+      "Effect": "Allow",
+      "Principal": {
+          "Service":[
+              "cloudwatch.amazonaws.com"
+          ]
+      },
+      "Action": [
+          "kms:Decrypt","kms:GenerateDataKey"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}

--- a/config/terraform/aws/sns.tf
+++ b/config/terraform/aws/sns.tf
@@ -20,7 +20,7 @@ resource "aws_sns_topic" "alert_warning_us_east" {
   provider = aws.us-east-1
 
   name              = "alert-warning"
-  kms_master_key_id = aws_kms_key.cw.arn
+  kms_master_key_id = aws_kms_key.cw_us_east.arn
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
@@ -31,7 +31,7 @@ resource "aws_sns_topic" "alert_critical_us_east" {
   provider = aws.us-east-1
 
   name              = "alert-critical"
-  kms_master_key_id = aws_kms_key.cw.arn
+  kms_master_key_id = aws_kms_key.cw_us_east.arn
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value


### PR DESCRIPTION
SNS topics in the US need access to a US encryption key. The SNS topics are used for Route53 and Shield alerts. The reason why we need to SNS topics in US-East is because Route53 and Shield for Cloudfront are global resources, which report their metrics into US-East.