### PR TITLE
bump db and app replicas to 3 (separate AZs)

### DIFF
--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -73,7 +73,7 @@ resource "aws_ecs_service" "covidshield_key_retrieval" {
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 
-  desired_count                      = 2
+  desired_count                      = 3
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60
@@ -205,7 +205,7 @@ resource "aws_ecs_service" "covidshield_key_submission" {
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 
-  desired_count                      = 2
+  desired_count                      = 3
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60

--- a/config/terraform/aws/modules/codedeploy/main.tf
+++ b/config/terraform/aws/modules/codedeploy/main.tf
@@ -14,6 +14,11 @@ resource "aws_codedeploy_deployment_group" "app" {
     events  = ["DEPLOYMENT_FAILURE"]
   }
 
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
+  }
+
   blue_green_deployment_config {
     deployment_ready_option {
       action_on_timeout = var.action_on_timeout
@@ -25,10 +30,7 @@ resource "aws_codedeploy_deployment_group" "app" {
     }
   }
 
-  deployment_style {
-    deployment_option = "WITH_TRAFFIC_CONTROL"
-    deployment_type   = "BLUE_GREEN"
-  }
+
 
   ecs_service {
     cluster_name = var.cluster_name

--- a/config/terraform/aws/rds.tf
+++ b/config/terraform/aws/rds.tf
@@ -15,7 +15,7 @@ resource "aws_db_subnet_group" "covidshield" {
 }
 
 resource "aws_rds_cluster_instance" "covidshield_server_instances" {
-  count                        = 2
+  count                        = 3
   identifier                   = "${var.rds_server_db_name}-instance-${count.index}"
   cluster_identifier           = aws_rds_cluster.covidshield_server.id
   instance_class               = var.rds_server_instance_class

--- a/config/terraform/aws/variables.tf
+++ b/config/terraform/aws/variables.tf
@@ -57,7 +57,7 @@ variable "memory_scale_metric" {
 
 variable "min_capacity" {
   type    = number
-  default = 2
+  default = 3
 }
 
 variable "max_capacity" {


### PR DESCRIPTION
app replicas won't get bumped because of ignore_changes for autoscaling. However, autoscaling is disabled from codedeploy, will fix in another PR.