### PR TITLE
split the LB egress SG rules by target zone

### DIFF
--- a/config/terraform/aws/networking.tf
+++ b/config/terraform/aws/networking.tf
@@ -303,18 +303,35 @@ resource "aws_security_group" "covidshield_load_balancer" {
     cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:AWS008
   }
 
-  egress {
-    protocol    = "tcp"
-    from_port   = 8001
-    to_port     = 8001
-    cidr_blocks = [var.vpc_cidr_block]
+  dynamic "egress" {
+    for_each = [for s in toset(aws_subnet.covidshield_private) : {
+      cidr = s.cidr_block
+      zone = s.availability_zone
+    }]
+
+    content {
+      protocol    = "tcp"
+      from_port   = 8001
+      to_port     = 8001
+      cidr_blocks = [egress.value.cidr]
+      description = "retrieval target ${egress.value.zone}"
+    }
   }
 
-  egress {
-    protocol    = "tcp"
-    from_port   = 8000
-    to_port     = 8000
-    cidr_blocks = [var.vpc_cidr_block]
+
+  dynamic "egress" {
+    for_each = [for s in toset(aws_subnet.covidshield_private) : {
+      cidr = s.cidr_block
+      zone = s.availability_zone
+    }]
+
+    content {
+      protocol    = "tcp"
+      from_port   = 8000
+      to_port     = 8000
+      cidr_blocks = [egress.value.cidr]
+      description = "submission target ${egress.value.zone}"
+    }
   }
 
   tags = {


### PR DESCRIPTION
- splitting the LB egress rules by target zone allows for quicker and easier removal of a zone rule in the event of an AZ outage and the target group doesn't properly mark the AZ's target task as unhealthy.