### PR TITLE
Cloudfront waf updates

### DIFF
--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -62,4 +62,12 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
     minimum_protocol_version = "TLSv1.2_2018"
     ssl_support_method       = "sni-only"
   }
+
+  logging_config {
+    include_cookies = false
+    bucket          = aws_s3_bucket.cloudfront_logs.bucket_domain_name
+    prefix          = "cloudfront"
+  }
+
+  depends_on = [aws_s3_bucket.cloudfront_logs]
 }

--- a/config/terraform/aws/s3.tf
+++ b/config/terraform/aws/s3.tf
@@ -21,8 +21,40 @@ resource "aws_s3_bucket" "firehose_waf_logs" {
   #tfsec:ignore:AWS002
 }
 
+###
+# AWS S3 bucket - cloudfront log target
+###
+resource "aws_s3_bucket" "cloudfront_logs" {
+  bucket = "covid-shield-${var.environment}-cloudfront-logs"
+  acl    = "private"
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 90
+    }
+  }
+  #tfsec:ignore:AWS002
+}
+
 resource "aws_s3_bucket_public_access_block" "firehose_waf_logs" {
   bucket = aws_s3_bucket.firehose_waf_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
 
   block_public_acls       = true
   block_public_policy     = true

--- a/config/terraform/aws/waf.tf
+++ b/config/terraform/aws/waf.tf
@@ -541,7 +541,7 @@ resource "aws_wafv2_web_acl" "key_retrieval_cdn" {
 
     statement {
       rate_based_statement {
-        limit              = 1000
+        limit              = 10000
         aggregate_key_type = "IP"
       }
     }


### PR DESCRIPTION
- enable cloudfront logging for the retrieval distribution
- bump retrieval WAF rate limit rule from 1000 to 10,000reqs/5min/IP