### PR TITLE
add /exposure-configuration/present

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -19,7 +19,12 @@ func NewConfigServlet() srvutil.Servlet {
 type configServlet struct{}
 
 func (s *configServlet) RegisterRouting(r *mux.Router) {
+	r.HandleFunc("/exposure-configuration/present", s.exposurePresence)
 	r.HandleFunc("/exposure-configuration/{region:[\\w]+}.json", s.exposureConfig)
+}
+
+func (s *configServlet) exposurePresence(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *configServlet) exposureConfig(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This PR adds https://retrieval.covid-notification.alpha.canada.ca/exposure-configuration/present and responds with `204`. Explanation in [issue](https://github.com/cds-snc/covid-alert-app/issues/1003).