### PR TITLE
Fixes urandom in scratch containers

### DIFF
--- a/pkg/server/services.go
+++ b/pkg/server/services.go
@@ -27,7 +27,9 @@ func (s *servicesServlet) RegisterRouting(r *mux.Router) {
 	r.HandleFunc("/ping", s.ping)
 	r.HandleFunc("/present", s.exposurePresence)
 	r.HandleFunc("/version.json", s.version)
-	r.HandleFunc("/urandom.bin", s.urandom)
+	if os.Getenv("ENV") == "staging" {
+		r.HandleFunc("/urandom.bin", s.urandom)
+	}
 }
 
 func (s *servicesServlet) exposurePresence(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/services.go
+++ b/pkg/server/services.go
@@ -1,13 +1,9 @@
 package server
 
 import (
-	"crypto/rand"
 	"encoding/json"
-	"math/big"
 	"net/http"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/Shopify/goose/srvutil"
 	"github.com/gorilla/mux"
@@ -31,10 +27,7 @@ func (s *servicesServlet) RegisterRouting(r *mux.Router) {
 	r.HandleFunc("/ping", s.ping)
 	r.HandleFunc("/present", s.exposurePresence)
 	r.HandleFunc("/version.json", s.version)
-	if os.Getenv("ENV") == "staging" {
-		r.HandleFunc("/urandom.bin", s.urandom)
-		r.HandleFunc("/sample", s.sample)
-	}
+	r.HandleFunc("/urandom.bin", s.urandom)
 }
 
 func (s *servicesServlet) exposurePresence(w http.ResponseWriter, r *http.Request) {
@@ -76,59 +69,21 @@ func (s *servicesServlet) version(w http.ResponseWriter, r *http.Request) {
 func (s *servicesServlet) urandom(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	cmd, _ := exec.Command("head", "-c1000000", "/dev/urandom").Output()
+	f, err := os.Open("/dev/urandom")
+
+	if err != nil {
+		log(ctx, err).Info("error opening urandom")
+	}
+
+	bytes := make([]byte, 1000000)
+	_, err = f.Read(bytes)
+
+	if err != nil {
+		log(ctx, err).Info("error reading data")
+	}
 
 	w.Header().Add("Cache-Control", "application/octet-stream")
-	if _, err := w.Write([]byte(cmd)); err != nil {
+	if _, err := w.Write(bytes); err != nil {
 		log(ctx, err).Info("error writing response")
 	}
-}
-
-func (s *servicesServlet) sample(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	var code []string
-
-	for i := 0; i < 10000; i++ {
-		oneTimeCode, _ := generateOneTimeCode()
-		code = append(code, oneTimeCode)
-	}
-
-	w.Header().Add("Cache-Control", "no-store")
-	w.Header().Add("Content-Type", "text/plain; charset=utf-8")
-	if _, err := w.Write([]byte(strings.Join(code, "\n"))); err != nil {
-		log(ctx, err).Info("error writing response")
-	}
-}
-
-func generateOneTimeCode() (string, error) {
-	characterSets := [2][]rune{
-		[]rune("AEFHJKLQRSUWXYZ"),
-		[]rune("2456789"),
-	}
-
-	characterSetLength := int64(len(characterSets))
-
-	seg1, err := rand.Int(rand.Reader, big.NewInt(characterSetLength))
-	seg2, err := rand.Int(rand.Reader, big.NewInt(characterSetLength))
-	seg3, err := rand.Int(rand.Reader, big.NewInt(characterSetLength))
-
-	oneTimeCode := genRandom(characterSets[seg1.Int64()], 3) +
-		genRandom(characterSets[seg2.Int64()], 3) +
-		genRandom(characterSets[seg3.Int64()], 4)
-
-	return oneTimeCode, err
-}
-
-// Generates a string of random characters based on a
-// passed list of characters and a desired length. For each
-// position in the desired length, generates a random number
-// between 0 and the length of the character set.
-func genRandom(chars []rune, length int64) string {
-	var b strings.Builder
-	for i := int64(0); i < length; i++ {
-		nBig, _ := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
-		b.WriteRune(chars[nBig.Int64()])
-	}
-	return b.String()
 }


### PR DESCRIPTION
Removes the password sample endpoint as the work as been completed. This fixes the direct sampling of the `urandom` endpoint as the `head` command is not available in the scratch containers.