### PR TITLE
Part #1: set up buckets and origin

### DIFF
--- a/config/terraform/aws/s3.tf
+++ b/config/terraform/aws/s3.tf
@@ -13,7 +13,7 @@ resource "aws_s3_bucket" "exposure_config" {
   }
 
   logging {
-    target_bucket = "${aws_s3_bucket.exposure_config_logs.bucket}"
+    target_bucket = aws_s3_bucket.exposure_config_logs.bucket
   }
 }
 

--- a/config/terraform/aws/s3.tf
+++ b/config/terraform/aws/s3.tf
@@ -34,7 +34,7 @@ resource "aws_s3_bucket" "firehose_waf_logs" {
       days = 90
     }
   }
-  #tfsec:ignore:AWS002
+  #tfsec:ignore:AWS002 - Ignore log of logs
 }
 
 ###
@@ -57,7 +57,7 @@ resource "aws_s3_bucket" "cloudfront_logs" {
       days = 90
     }
   }
-  #tfsec:ignore:AWS002
+  #tfsec:ignore:AWS002 - Ignore log of logs
 }
 
 resource "aws_s3_bucket" "exposure_config_logs" {
@@ -78,7 +78,7 @@ resource "aws_s3_bucket" "exposure_config_logs" {
       days = 90
     }
   }
-  #tfsec:ignore:AWS002
+  #tfsec:ignore:AWS002 - Ignore log of logs
 }
 
 resource "aws_s3_bucket_public_access_block" "firehose_waf_logs" {

--- a/config/terraform/aws/s3.tf
+++ b/config/terraform/aws/s3.tf
@@ -4,6 +4,13 @@
 
 resource "aws_s3_bucket" "exposure_config" {
   bucket = "covid-shield-exposure-config-${var.environment}"
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 
   logging {
     target_bucket = "${aws_s3_bucket.exposure_config_logs.bucket}"
@@ -56,6 +63,13 @@ resource "aws_s3_bucket" "cloudfront_logs" {
 resource "aws_s3_bucket" "exposure_config_logs" {
   bucket = "covid-shield-exposure-config-${var.environment}-logs"
   acl    = "log-delivery-write"
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 
   lifecycle_rule {
     enabled = true

--- a/config/terraform/aws/s3.tf
+++ b/config/terraform/aws/s3.tf
@@ -1,6 +1,15 @@
 ###
 # AWS S3 bucket - WAF log target
 ###
+
+resource "aws_s3_bucket" "exposure_config" {
+  bucket = "covid-shield-exposure-config-${var.environment}"
+
+  logging {
+    target_bucket = "${aws_s3_bucket.exposure_config_logs.bucket}"
+  }
+}
+
 resource "aws_s3_bucket" "firehose_waf_logs" {
   bucket = "covid-shield-${var.environment}-waf-logs"
   acl    = "private"
@@ -44,6 +53,20 @@ resource "aws_s3_bucket" "cloudfront_logs" {
   #tfsec:ignore:AWS002
 }
 
+resource "aws_s3_bucket" "exposure_config_logs" {
+  bucket = "covid-shield-exposure-config-${var.environment}-logs"
+  acl    = "log-delivery-write"
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 90
+    }
+  }
+  #tfsec:ignore:AWS002
+}
+
 resource "aws_s3_bucket_public_access_block" "firehose_waf_logs" {
   bucket = aws_s3_bucket.firehose_waf_logs.id
 
@@ -61,3 +84,15 @@ resource "aws_s3_bucket_public_access_block" "cloudfront_logs" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+resource "aws_s3_bucket_public_access_block" "exposure_config_logs" {
+  bucket = aws_s3_bucket.exposure_config_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+
+


### PR DESCRIPTION
Part of #195. 

This creates a new s3 bucket that will house all the content for requests going to the retrieval `/exposure-configuration/`. It also adds logging to that bucket. 

Additionally it adds the bucket to the cloudfront distribution, however, routing to the bucket is still turned off, as there is no content in the bucket. If we enable routing, the time between adding the bucket and populating it would break the endpoint.

We will add the routing once the content has been populated.