### PR TITLE
Part 2: Redirect CF traffic and set bucket permissions

### DIFF
--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -63,25 +63,25 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
   }
 
   ordered_cache_behavior {
-   path_pattern     = "/exposure-configuration/*"
-   allowed_methods  = ["GET", "HEAD"]
-   cached_methods   = ["GET", "HEAD"]
-   target_origin_id = "covid-shield-exposure-config-${var.environment}"
+    path_pattern     = "/exposure-configuration/*"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "covid-shield-exposure-config-${var.environment}"
 
-   forwarded_values {
-     query_string = false
-     headers      = ["Origin"]
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
 
-     cookies {
-       forward = "none"
-     }
-   }
+      cookies {
+        forward = "none"
+      }
+    }
 
-   viewer_protocol_policy = "https-only"
-   min_ttl                = 0
-   default_ttl            = 86400
-   max_ttl                = 31536000
-   compress               = true
+    viewer_protocol_policy = "https-only"
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
   }
 
 

--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -62,27 +62,27 @@ resource "aws_cloudfront_distribution" "key_retrieval_distribution" {
     compress               = true
   }
 
-  # ordered_cache_behavior {
-  #  path_pattern     = "/exposure-configuration/*"
-  #  allowed_methods  = ["GET", "HEAD"]
-  #  cached_methods   = ["GET", "HEAD"]
-  #  target_origin_id = "covid-shield-exposure-config-${var.environment}"
+  ordered_cache_behavior {
+   path_pattern     = "/exposure-configuration/*"
+   allowed_methods  = ["GET", "HEAD"]
+   cached_methods   = ["GET", "HEAD"]
+   target_origin_id = "covid-shield-exposure-config-${var.environment}"
 
-  #  forwarded_values {
-  #    query_string = false
-  #    headers      = ["Origin"]
+   forwarded_values {
+     query_string = false
+     headers      = ["Origin"]
 
-  #    cookies {
-  #      forward = "none"
-  #    }
-  #  }
+     cookies {
+       forward = "none"
+     }
+   }
 
-  #  viewer_protocol_policy = "https-only"
-  #  min_ttl                = 0
-  #  default_ttl            = 86400
-  #  max_ttl                = 31536000
-  #  compress               = true
-  # }
+   viewer_protocol_policy = "https-only"
+   min_ttl                = 0
+   default_ttl            = 86400
+   max_ttl                = 31536000
+   compress               = true
+  }
 
 
   price_class = "PriceClass_100"

--- a/config/terraform/aws/s3.tf
+++ b/config/terraform/aws/s3.tf
@@ -17,6 +17,29 @@ resource "aws_s3_bucket" "exposure_config" {
   }
 }
 
+resource "aws_s3_bucket_policy" "exposure_config" {
+  bucket = aws_s3_bucket.exposure_config.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "OnlyCloudfrontReadAccess",
+      "Principal": {
+        "AWS": "${aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"
+      },
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": "${aws_s3_bucket.exposure_config.id}/*"
+    }
+  ]
+}
+POLICY
+}
+
 resource "aws_s3_bucket" "firehose_waf_logs" {
   bucket = "covid-shield-${var.environment}-waf-logs"
   acl    = "private"


### PR DESCRIPTION
Concludes #195 

This is a follow up on #249 where we created the CloudFront origin and the S3 bucket. We have now populated the CF bucket with the correct content.

This PR changes the CloudFront distribution to redirect traffic for the `/exposure-configuration/` path to the S3 bucket. It also adds a bucket permission so that only the CloudFront distribution can access the contents of the S3 bucket.