### PR TITLE
[Makefile] Add format target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ RELEASE_BUILDS := $(patsubst %,build/release/%,$(CMDS))
 DEBUG_BUILDS   := $(patsubst %,build/debug/%,$(CMDS))
 
 GO              := go
+GOFMT           := gofmt
 PROTOC          := protoc
 GCFLAGS         :=
 GCFLAGS_RELEASE := $(GCFLAGS)
@@ -77,4 +78,7 @@ clean-proto:
 	@echo "                   \x1b[1;31mrm\x1b[0m  $(RPC_RB)"
 	@rm -f $(RPC_RB)
 
-.PHONY: all default release generate clean test proto clean-proto
+format:
+	@$(GOFMT) -w .
+
+.PHONY: all default release generate clean test proto clean-proto format

--- a/pkg/persistence/migrator.go
+++ b/pkg/persistence/migrator.go
@@ -93,7 +93,6 @@ CREATE TABLE IF NOT EXISTS failed_key_claim_attempts (
 	},
 }
 
-
 // MigrateDatabase creates the database and migrates it into the correct state.
 func MigrateDatabase(url string) error {
 	parts := strings.Split(url, "/")

--- a/pkg/proto/covidshield/defs.go
+++ b/pkg/proto/covidshield/defs.go
@@ -16,7 +16,7 @@ const (
 	// which the Key is rolled.
 	// 144 * 600 = 86400 (1 day)
 	MaxTEKRollingPeriod = 144
-	MaxKeysInUpload  = 28
+	MaxKeysInUpload     = 28
 )
 
 func IntoKey(bytes []byte) (*[KeyLength]byte, error) {

--- a/pkg/server/upload.go
+++ b/pkg/server/upload.go
@@ -188,7 +188,7 @@ func (s *uploadServlet) upload(w http.ResponseWriter, r *http.Request) {
 }
 
 func validateKey(ctx context.Context, w http.ResponseWriter, key *pb.TemporaryExposureKey) bool {
-	if key.GetRollingPeriod() < 1 || key.GetRollingPeriod() > 144{
+	if key.GetRollingPeriod() < 1 || key.GetRollingPeriod() > 144 {
 		requestError(
 			ctx, w, nil, "missing or invalid rollingPeriod",
 			http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_INVALID_ROLLING_PERIOD),

--- a/pkg/timemath/timemath.go
+++ b/pkg/timemath/timemath.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	SecondsInHour  = 3600
-	SecondsInDay   = 86400
-	HoursInDay     = 24
+	SecondsInHour = 3600
+	SecondsInDay  = 86400
+	HoursInDay    = 24
 )
 
 func HourNumber(t time.Time) uint32 {


### PR DESCRIPTION
Adds a new makefile target for formatting code and runs it on existing code. In the future we can probably add a CI step to check that `gofmt` does not result in any modifications.