### PR TITLE
refactor(workers): Refactors location of worker code to add more workers

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -10,11 +10,11 @@ import (
 	"github.com/Shopify/goose/srvutil"
 
 	"github.com/CovidShield/server/pkg/config"
-	"github.com/CovidShield/server/pkg/expiration"
 	"github.com/CovidShield/server/pkg/keyclaim"
 	"github.com/CovidShield/server/pkg/persistence"
 	"github.com/CovidShield/server/pkg/retrieval"
 	"github.com/CovidShield/server/pkg/server"
+	"github.com/CovidShield/server/pkg/workers"
 )
 
 var log = logger.New("app")
@@ -94,8 +94,8 @@ func bindAddr(defaultPort uint32) string {
 	return fmt.Sprintf("0.0.0.0:%d", defaultPort)
 }
 
-func newExpirationWorker(db persistence.Conn) expiration.Worker {
-	worker, err := expiration.StartWorker(db)
+func newExpirationWorker(db persistence.Conn) workers.Worker {
+	worker, err := workers.StartExpirationWorker(db)
 	fatalIfErr(err, "failed to do initial run of expiration worker")
 	return worker
 }

--- a/pkg/workers/expiration.go
+++ b/pkg/workers/expiration.go
@@ -1,4 +1,4 @@
-package expiration
+package workers
 
 import (
 	"context"
@@ -71,7 +71,7 @@ func (w *worker) Tomb() *tomb.Tomb {
 	return w.tomb
 }
 
-func StartWorker(db persistence.Conn) (Worker, error) {
+func StartExpirationWorker(db persistence.Conn) (Worker, error) {
 	return create(db, time.Duration(config.AppConstants.WorkerExpirationInterval)*time.Second)
 }
 


### PR DESCRIPTION
## Description of what your PR accomplishes:

This is a small refactor of the code that moves the expiration worker from its own `expiration` directory to a `workers` directory. This would allow us to add additional `worker` instances and keep the organized. For example we may want a stats aggregator worker that runs every sixty minutes vs the thirty seconds that the current expiration worked is running on.

## Why this approach? Any notable design decisions?

We could have included each worker in their own subdirectory, however, there is some shared code we us per worker, ex the `worker` struct. It would probably make sense to share that code.

## Anything the reviewers should focus on? Any discussion points?

Alternative implementations.
