### PR TITLE
S3 bucket content checks

### DIFF
--- a/config/terraform/aws/cloudwatch.tf
+++ b/config/terraform/aws/cloudwatch.tf
@@ -429,7 +429,7 @@ resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
 resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
   provider = aws.us-east-1
 
-  alarm_name          = "Route53RetrievalHealthCheck"
+  alarm_name          = "Route53RetrievalHealthCheckCAJson"
   alarm_description   = "Check that the Retrieval server is correctly serving CA.json"
   comparison_operator = "LessThanThreshold"
   metric_name         = "HealthCheckStatus"
@@ -450,7 +450,7 @@ resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
 resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
   provider = aws.us-east-1
 
-  alarm_name          = "Route53RetrievalHealthCheck"
+  alarm_name          = "Route53RetrievalHealthCheckRegionJson"
   alarm_description   = "Check that the Retrieval server is correctly serving region.json"
   comparison_operator = "LessThanThreshold"
   metric_name         = "HealthCheckStatus"

--- a/config/terraform/aws/cloudwatch.tf
+++ b/config/terraform/aws/cloudwatch.tf
@@ -426,6 +426,48 @@ resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
+  provider = aws.us-east-1
+
+  alarm_name          = "Route53RetrievalHealthCheck"
+  alarm_description   = "Check that the Retrieval server is correctly serving CA.json"
+  comparison_operator = "LessThanThreshold"
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = "60"
+  evaluation_periods  = "2"
+  statistic           = "Average"
+  threshold           = "1"
+  treat_missing_data  = "breaching"
+
+  alarm_actions = [aws_sns_topic.alert_warning_us_east.arn, aws_sns_topic.alert_critical_us_east.arn]
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.covidshield_key_retrieval_healthcheck_ca_json.id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
+  provider = aws.us-east-1
+
+  alarm_name          = "Route53RetrievalHealthCheck"
+  alarm_description   = "Check that the Retrieval server is correctly serving region.json"
+  comparison_operator = "LessThanThreshold"
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = "60"
+  evaluation_periods  = "2"
+  statistic           = "Average"
+  threshold           = "1"
+  treat_missing_data  = "breaching"
+
+  alarm_actions = [aws_sns_topic.alert_warning_us_east.arn, aws_sns_topic.alert_critical_us_east.arn]
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.covidshield_key_retrieval_healthcheck_region_json.id
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "route53_submission_health_check" {
   provider = aws.us-east-1
 

--- a/config/terraform/aws/cloudwatch.tf
+++ b/config/terraform/aws/cloudwatch.tf
@@ -426,7 +426,7 @@ resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
+resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check_ca_json" {
   provider = aws.us-east-1
 
   alarm_name          = "Route53RetrievalHealthCheckCAJson"
@@ -447,7 +447,7 @@ resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check" {
+resource "aws_cloudwatch_metric_alarm" "route53_retrieval_health_check_region_json" {
   provider = aws.us-east-1
 
   alarm_name          = "Route53RetrievalHealthCheckRegionJson"

--- a/config/terraform/aws/route53.tf
+++ b/config/terraform/aws/route53.tf
@@ -39,6 +39,34 @@ resource "aws_route53_health_check" "covidshield_key_retrieval_healthcheck" {
   }
 }
 
+resource "aws_route53_health_check" "covidshield_key_retrieval_healthcheck_ca_json" {
+  fqdn              = "retrieval.${var.route53_zone_name}"
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/exposure-configuration/CA.json"
+  failure_threshold = "3"
+  request_interval  = "30"
+  regions           = ["us-west-2","us-east-1","us-west-1"]
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}
+
+resource "aws_route53_health_check" "covidshield_key_retrieval_healthcheck_region_json" {
+  fqdn              = "retrieval.${var.route53_zone_name}"
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/exposure-configuration/region.json"
+  failure_threshold = "3"
+  request_interval  = "30"
+  regions           = ["us-west-2","us-east-1","us-west-1"]
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}
+
 ###
 # Route53 Record - Key Submission
 ###

--- a/config/terraform/aws/route53.tf
+++ b/config/terraform/aws/route53.tf
@@ -46,7 +46,7 @@ resource "aws_route53_health_check" "covidshield_key_retrieval_healthcheck_ca_js
   resource_path     = "/exposure-configuration/CA.json"
   failure_threshold = "3"
   request_interval  = "30"
-  regions           = ["us-west-2","us-east-1","us-west-1"]
+  regions           = ["us-west-2", "us-east-1", "us-west-1"]
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
@@ -60,7 +60,7 @@ resource "aws_route53_health_check" "covidshield_key_retrieval_healthcheck_regio
   resource_path     = "/exposure-configuration/region.json"
   failure_threshold = "3"
   request_interval  = "30"
-  regions           = ["us-west-2","us-east-1","us-west-1"]
+  regions           = ["us-west-2", "us-east-1", "us-west-1"]
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value


### PR DESCRIPTION
Fixes: #267 

## Description of what your PR accomplishes:

Adds Route53 health checks to the static content served up by the S3 buckets. AWS has canaries that can do this, however, they do not exist in terraform yet. The drawback of Route53 checks is that they run every 30 seconds and from multiple regions, which will increase the traffic to those endpoints. However, the tradeoff is not significant enough to remove these from Terraform.

## Why this approach? Any notable design decisions?

The code limits the regions from the maximum eight to the minimum three from which health checks are run.

## Anything the reviewers should focus on? Any discussion points?
