### PR TITLE
CI: Fixes the CI for conventional commits 

### DIFF
--- a/.clconfig.js
+++ b/.clconfig.js
@@ -1,0 +1,19 @@
+'use strict'
+const config = require('conventional-changelog-conventionalcommits');
+
+module.exports = config({
+  "types" : [
+    { type: 'feat', section: 'Features' },
+    { type: 'feature', section: 'Features' },
+    { type: 'fix', section: 'Bug Fixes' },
+    { type: 'perf', section: 'Performance Improvements' },
+    { type: 'revert', section: 'Reverts' },
+    { type: 'docs', section: 'Documentation'},
+    { type: 'style', section: 'Styles'},
+    { type: 'chore', section: 'Miscellaneous Chores', hidden: true },
+    { type: 'refactor', section: 'Code Refactoring'},
+    { type: 'test', section: 'Tests'},
+    { type: 'build', section: 'Build System'},
+    { type: 'ci', section: 'Continuous Integration'}
+  ]
+})

--- a/.github/workflows/build-push-containers.yml
+++ b/.github/workflows/build-push-containers.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Install Config for Changelog
+        run: npm i conventional-changelog-conventionalcommits
+        
       - name: Generate Changelog and Bump Version
         id: bump-version
         uses: TriPSs/conventional-changelog-action@1643d852ba88d583cc2bacade8ec0e9436a5a6ba
@@ -23,6 +26,8 @@ jobs:
           skip-version-file: 'true'
           # For format see: https://www.conventionalcommits.org/en/v1.0.0/
           preset: 'conventionalcommits'
+          skip-on-empty: 'false'
+          config-file-path: '.clconfig.js'
 
       - name: Configure Staging AWS credentials
         id: aws-staging

--- a/.github/workflows/deploy-containers.yml
+++ b/.github/workflows/deploy-containers.yml
@@ -22,6 +22,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Wait for terraform apply
+        if: steps.wait-for-build.outputs.conclusion == 'success'
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-terraform
         with:
@@ -30,10 +31,11 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Checkout
-        if: steps.wait-for-build.outputs.conclusion == 'success'
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         uses: actions/checkout@v2
 
       - name: Configure AWS credentials
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -41,21 +43,25 @@ jobs:
           aws-region: ca-central-1
 
       - name: Login to Amazon ECR
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Get Cluster Name
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         id: cluster
         run: |
           echo "##[set-output name=name;]$(aws ecs list-clusters | jq -r '.clusterArns[0]' | cut -f 2 -d "/" )"
 
       - name: Download retrieval task definition
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         id: download-taskdef-retrieval
         run: |
           aws ecs describe-task-definition --task-definition KeyRetrieval --query taskDefinition > task-definition-retrieval.json
           echo "##[set-output name=container_name;]$(jq -r '.containerDefinitions[0].name' task-definition-retrieval.json)"
 
       - name: Render image for retrieval service
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         id: taskdef-retrieval
         uses: aws-actions/amazon-ecs-render-task-definition@9666dc9
         with:
@@ -64,6 +70,7 @@ jobs:
           image: ${{ steps.login-ecr.outputs.registry }}/covid-server/key-retrieval:${{ github.sha }}
 
       - name: Render appspec for retrieval service
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         run: |
           CONTAINER_PORT=`jq '.containerDefinitions[0].portMappings[0].containerPort' task-definition-retrieval.json`
           CONTAINER_NAME=${{ steps.download-taskdef-retrieval.outputs.container_name }}
@@ -72,6 +79,7 @@ jobs:
           jq  --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" --arg lambda "$LAMBDA" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port | .Hooks[0].BeforeAllowTraffic = $lambda ' config/infrastructure/aws/appspec-template.json > covidshield-retrieval-appspec.json
 
       - name: Deploy image for retrieval service
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         timeout-minutes: 10
         uses: aws-actions/amazon-ecs-deploy-task-definition@7218b9c
         with:
@@ -98,6 +106,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Wait for terraform apply
+        if: steps.wait-for-build.outputs.conclusion == 'success'
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-terraform
         with:
@@ -106,10 +115,11 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Checkout
-        if: steps.wait-for-build.outputs.conclusion == 'success'
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         uses: actions/checkout@v2
 
       - name: Configure AWS credentials
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -117,21 +127,25 @@ jobs:
           aws-region: ca-central-1
 
       - name: Login to Amazon ECR
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Get Cluster Name
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         id: cluster
         run: |
           echo "##[set-output name=name;]$(aws ecs list-clusters | jq -r '.clusterArns[0]' | cut -f 2 -d "/" )"
 
       - name: Download submission task definition
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         id: download-taskdef-submission
         run: |
           aws ecs describe-task-definition --task-definition KeySubmission --query taskDefinition > task-definition-submission.json
           echo "##[set-output name=container_name;]$(jq -r '.containerDefinitions[0].name' task-definition-submission.json)"
 
       - name: Render image for submission service
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         id: taskdef-submission
         uses: aws-actions/amazon-ecs-render-task-definition@9666dc9
         with:
@@ -140,6 +154,7 @@ jobs:
           image: ${{ steps.login-ecr.outputs.registry }}/covid-server/key-submission:${{ github.sha }}
 
       - name: Render appspec for submission service
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         run: |
           CONTAINER_PORT=`jq '.containerDefinitions[0].portMappings[0].containerPort' task-definition-submission.json`
           CONTAINER_NAME=${{ steps.download-taskdef-submission.outputs.container_name }}
@@ -148,6 +163,7 @@ jobs:
           jq  --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" --arg lambda "$LAMBDA" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port | .Hooks[0].BeforeAllowTraffic = $lambda ' config/infrastructure/aws/appspec-template.json > covidshield-submission-appspec.json
 
       - name: Deploy image for submission service
+        if: steps.wait-for-terraform.outputs.conclusion == 'success'
         timeout-minutes: 10
         uses: aws-actions/amazon-ecs-deploy-task-definition@7218b9c
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 config/terraform/*/.terraform/*
 config/terraform/*/terraform.tfstate*
 /server
+node_modules


### PR DESCRIPTION
- Install config using NPM so we can reference the config in`.clconfig.js`
- Add node_modules to .gitignore so it doesn't get commited when the changelog commits
- Run the changelog on empty commits so we don't break CI
- add configuration to output more commits to the changelog
- tag a new version even if no output to change log
- make deploy-containers action contingent on terraform and build
  success