### PR TITLE
Add worker defs

### DIFF
--- a/pkg/workers/defs.go
+++ b/pkg/workers/defs.go
@@ -1,0 +1,43 @@
+package workers
+
+import (
+	"context"
+	"time"
+
+	"github.com/CovidShield/server/pkg/persistence"
+	"github.com/Shopify/goose/genmain"
+	"github.com/Shopify/goose/logger"
+	"gopkg.in/tomb.v2"
+)
+
+var log = logger.New("workers")
+
+type Worker interface {
+	genmain.Component
+}
+
+type worker struct {
+	name     string
+	db       persistence.Conn
+	interval time.Duration
+	tomb     *tomb.Tomb
+	runner   func(w *worker, ctx context.Context) error
+}
+
+func (w *worker) Run() error {
+	for {
+		select {
+		case <-w.tomb.Dying():
+			return nil
+		case <-time.After(w.interval):
+			ctx, _ := logger.WithUUID(context.Background())
+			if err := w.runner(w, ctx); err != nil {
+				log(ctx, err).WithField("name", w.name).Error("worker failed to run")
+			}
+		}
+	}
+}
+
+func (w *worker) Tomb() *tomb.Tomb {
+	return w.tomb
+}


### PR DESCRIPTION
refactor(workers): makes workers more modular by abstracting the base genmain functions

## Description of what your PR accomplishes:

Extension of #272. This allows a generic definition for workers to be used so it should be easier to add additional workers. the `worker` type went from 

```
type worker struct {
	db       persistence.Conn
	interval time.Duration
	tomb     *tomb.Tomb
}
```

to 

```
type worker struct {
	name     string
	db       persistence.Conn
	interval time.Duration
	tomb     *tomb.Tomb
	runner   func(w *worker, ctx context.Context) error
}
```

The new `name` attribute is used for logging purposes because previously there was a global definition using the `expiration` namespace for logging on the worker.

The new `runner` attribute is the function that gets run when the `genmain` `Run` function is executed at the specified interval.

## Why this approach? Any notable design decisions?

Hopefully makes it easier to implement new workers.