### PR TITLE
feat: Remove key count logging

### DIFF
--- a/pkg/persistence/db_test.go
+++ b/pkg/persistence/db_test.go
@@ -436,8 +436,6 @@ func TestDBStoreKeys(t *testing.T) {
 	}
 
 	assert.Nil(t, receivedResult, "Expected nil when keys are commited")
-
-	assertLog(t, hook, 1, logrus.InfoLevel, "Inserted keys")
 }
 
 func TestDBFetchKeysForHours(t *testing.T) {

--- a/pkg/persistence/db_test.go
+++ b/pkg/persistence/db_test.go
@@ -365,17 +365,6 @@ func TestDBPrivForPub(t *testing.T) {
 }
 
 func TestDBStoreKeys(t *testing.T) {
-	// Capture logs
-	oldLog := log
-	defer func() { log = oldLog }()
-
-	nullLog, hook := test.NewNullLogger()
-	nullLog.ExitFunc = func(code int) {}
-
-	log = func(ctx logger.Valuer, err ...error) *logrus.Entry {
-		return logrus.NewEntry(nullLog)
-	}
-
 	db, mock, _ := sqlmock.New(sqlmock.QueryMatcherOption(allQueryMatcher))
 	defer db.Close()
 

--- a/pkg/persistence/queries.go
+++ b/pkg/persistence/queries.go
@@ -297,7 +297,6 @@ func registerDiagnosisKeys(db *sql.DB, appPubKey *[32]byte, keys []*pb.Temporary
 	if err = tx.Commit(); err != nil {
 		return err
 	}
-	log(nil, nil).WithField("keys", keysInserted).Info("Inserted keys")
 	return nil
 }
 

--- a/pkg/persistence/queries_test.go
+++ b/pkg/persistence/queries_test.go
@@ -767,8 +767,6 @@ func TestRegisterDiagnosisKeys(t *testing.T) {
 	}
 
 	assert.Nil(t, receivedResult, "Expected nil when keys are commited")
-
-	assertLog(t, hook, 1, logrus.InfoLevel, "Inserted keys")
 }
 
 func TestCheckClaimKeyBan(t *testing.T) {

--- a/pkg/persistence/queries_test.go
+++ b/pkg/persistence/queries_test.go
@@ -10,9 +10,6 @@ import (
 	pb "github.com/CovidShield/server/pkg/proto/covidshield"
 	"github.com/CovidShield/server/pkg/timemath"
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/Shopify/goose/logger"
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/nacl/box"
 )
@@ -527,17 +524,6 @@ func TestDiagnosisKeysForHours(t *testing.T) {
 func TestRegisterDiagnosisKeys(t *testing.T) {
 	db, mock, _ := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	defer db.Close()
-
-	// Capture logs
-	oldLog := log
-	defer func() { log = oldLog }()
-
-	nullLog, hook := test.NewNullLogger()
-	nullLog.ExitFunc = func(code int) {}
-
-	log = func(ctx logger.Valuer, err ...error) *logrus.Entry {
-		return logrus.NewEntry(nullLog)
-	}
 
 	pub, _, _ := box.GenerateKey(rand.Reader)
 	keys := []*pb.TemporaryExposureKey{}


### PR DESCRIPTION
Removes a log of how many keys were uploaded. We do not need this information any more and it just increases the information exposure for some of the future features we are planning.
