### PR TITLE
chore(dev_container): fixes dev tools on dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,9 @@
 	},
 
 	"extensions": [
+		"golang.go",
 		"rebornix.Ruby"
 	],
 
-	"postCreateCommand": "export PATH=/usr/local/go/bin:$PATH && bundle install && GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go",
+	"postCreateCommand": "bash /workspace/scripts/install_dev_tools.sh",
 }

--- a/Makefile
+++ b/Makefile
@@ -37,45 +37,45 @@ proto:    $(PROTO_GO) $(PROTO_RB) $(RPC_RB)
 
 build/debug/%: $(GOFILES) $(PROTO_GO)
 	@mkdir -p "$(@D)"
-	@echo "     \x1b[1;34mgo build \x1b[0;1m(debug)\x1b[0m  $@"
+	@echo "     \e[1;34mgo build \e[0;1m(debug)\e[0m  $@"
 	@$(GO) build -trimpath -i -ldflags=$(GOLDFLAGS) -o "$@" -gcflags "$(GCFLAGS_DEBUG)" "$(MODULE)/cmd/$(@F)"
 
 build/release/%: $(GOFILES) $(PROTO_GO)
 	@mkdir -p "$(@D)"
-	@echo "   \x1b[1;34mgo build \x1b[0;1m(release)\x1b[0m  $@"
+	@echo "   \e[1;34mgo build \e[0;1m(release)\e[0m  $@"
 	@$(GO) build -trimpath -i -ldflags=$(GOLDFLAGS) -o "$@" -gcflags "$(GCFLAGS_RELEASE)" "$(MODULE)/cmd/$(@F)"
 
 pkg/proto/%/proto.pb.go: proto/%.proto
 	@mkdir -p "$(@D)"
-	@echo "          \x1b[1;34mprotoc \x1b[0;1m(go)\x1b[0m  $@"
+	@echo "          \e[1;34mprotoc \e[0;1m(go)\e[0m  $@"
 	@$(PROTOC) --go_out=. "--proto_path=$(*D)" "$<"
 	@mv "$(@D)/$(patsubst %.proto,%,$(*F)).pb.go" "$(@D)/proto.pb.go"
 
 test/lib/protocol/%_pb.rb: proto/%.proto
 	@mkdir -p "$(@D)"
-	@echo "          \x1b[1;34mprotoc \x1b[0;1m(rb)\x1b[0m  $@"
+	@echo "          \e[1;34mprotoc \e[0;1m(rb)\e[0m  $@"
 	@grpc_tools_ruby_protoc -I ./proto --ruby_out=test/lib/protocol "$<"
 
 test/lib/protocol/%_services_pb.rb: proto/%.proto
 	@mkdir -p "$(@D)"
-	@echo "          \x1b[1;34mprotoc \x1b[0;1m(rb)\x1b[0m  $@"
+	@echo "          \e[1;34mprotoc \e[0;1m(rb)\e[0m  $@"
 	@grpc_tools_ruby_protoc -I ./proto --grpc_out=test/lib/protocol "$<"
 
 test: debug $(PROTO_RB) $(RPC_RB)
 	ruby $(foreach file,$(TEST_FILES),-r ./$(file)) -e ''
 
 clean:
-	@echo "                   \x1b[1;31mrm\x1b[0m  $(CMDS)"
+	@echo "                   \e[1;31mrm\e[0m  $(CMDS)"
 	@rm -f $(CMDS)
-	@echo "                   \x1b[1;31mrm\x1b[0m  build"
+	@echo "                   \e[1;31mrm\e[0m  build"
 	@rm -rf build
 
 clean-proto:
-	@echo "                   \x1b[1;31mrm\x1b[0m  $(PROTO_GO)"
+	@echo "                   \e[1;31mrm\e[0m  $(PROTO_GO)"
 	@rm -f $(PROTO_GO)
-	@echo "                   \x1b[1;31mrm\x1b[0m  $(PROTO_RB)"
+	@echo "                   \e[1;31mrm\e[0m  $(PROTO_RB)"
 	@rm -f $(PROTO_RB)
-	@echo "                   \x1b[1;31mrm\x1b[0m  $(RPC_RB)"
+	@echo "                   \e[1;31mrm\e[0m  $(RPC_RB)"
 	@rm -f $(RPC_RB)
 
 format:

--- a/scripts/install_dev_tools.sh
+++ b/scripts/install_dev_tools.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+export PATH=/usr/local/go/bin:$PATH
+export GOPATH=/root/go
+export GOBIN=/usr/local/bin 
+export GO111MODULE=on
+
+bundle install 
+
+go install google.golang.org/protobuf/cmd/protoc-gen-go
+
+cd /
+
+go mod init foo/bar
+
+GOPATH=/root/go go get -u github.com/mdempsky/gocode
+GOPATH=/root/go go get -u github.com/uudashr/gopkgs/v2/cmd/gopkgs
+GOPATH=/root/go go get -u github.com/ramya-rao-a/go-outline
+GOPATH=/root/go go get -u github.com/acroca/go-symbols
+GOPATH=/root/go go get -u golang.org/x/tools/cmd/guru
+GOPATH=/root/go go get -u golang.org/x/tools/cmd/gorename
+GOPATH=/root/go go get -u github.com/cweill/gotests/...
+GOPATH=/root/go go get -u github.com/fatih/gomodifytags
+GOPATH=/root/go go get -u github.com/josharian/impl
+GOPATH=/root/go go get -u github.com/davidrjenni/reftools/cmd/fillstruct
+GOPATH=/root/go go get -u github.com/haya14busa/goplay/cmd/goplay
+GOPATH=/root/go go get -u github.com/godoctor/godoctor
+GOPATH=/root/go go get -u github.com/go-delve/delve/cmd/dlv
+GOPATH=/root/go go get -u github.com/stamblerre/gocode
+GOPATH=/root/go go get -u github.com/rogpeppe/godef
+GOPATH=/root/go go get -u golang.org/x/tools/cmd/goimports
+GOPATH=/root/go go get -u golang.org/x/lint/golint
+GOPATH=/root/go go get -u github.com/stamblerre/gocode 


### PR DESCRIPTION
Closes #269 

This takes care of some technical debt we had on the dev container for vscode. 

- Added `golang.go` extension to build process for dev container
- Refactored `postCreateCommand` into a script in `scripts/install-dev-tools.sh`, which installs all the go tools that are installed by the extension

Installed go tools are:

```
github.com/mdempsky/gocode
github.com/uudashr/gopkgs/v2/cmd/gopkgs
github.com/ramya-rao-a/go-outline
github.com/acroca/go-symbols
golang.org/x/tools/cmd/guru
golang.org/x/tools/cmd/gorename
github.com/cweill/gotests/...
github.com/fatih/gomodifytags
github.com/josharian/impl
github.com/davidrjenni/reftools/cmd/fillstruct
github.com/haya14busa/goplay/cmd/goplay
github.com/godoctor/godoctor
github.com/go-delve/delve/cmd/dlv
github.com/stamblerre/gocode
github.com/rogpeppe/godef
golang.org/x/tools/cmd/goimports
golang.org/x/lint/golint
github.com/stamblerre/gocode 
```