### PR TITLE
build: push monolith image to GCR

### DIFF
--- a/.github/workflows/build-push-gcr.yml
+++ b/.github/workflows/build-push-gcr.yml
@@ -7,7 +7,7 @@ env:
   BRANCH: ${{ github.ref }}
 
 jobs:
-  build-n-push:
+  build-and-push-gcr:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,7 +30,7 @@ jobs:
         run: |
           docker build --build-arg branch=$BRANCH --build-arg revision=$GITHUB_SHA --build-arg component=monolith \
           -t gcr.io/cdssnc/covid-alert/server:$GITHUB_SHA \
-          -t gcr.io/cdssnc/covid-alert/server:latest \
+          -t gcr.io/cdssnc/covid-alert/server:latest .
 
       - name: Push containers to GCR
         run: |

--- a/.github/workflows/build-push-gcr.yml
+++ b/.github/workflows/build-push-gcr.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Configure gCloud credentials
         id: gcloud-login
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@3025a7711899c25380bbef9ba82f89714de40c95
         with:
           version: '290.0.1'
           project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/build-push-gcr.yml
+++ b/.github/workflows/build-push-gcr.yml
@@ -1,6 +1,8 @@
 name: Build and Push monolith to Google Cloud
 
-on: [pull_request]
+on:
+  push:
+    branches: [master]
 
 env:
   GITHUB_SHA: ${{ github.sha }}

--- a/.github/workflows/build-push-gcr.yml
+++ b/.github/workflows/build-push-gcr.yml
@@ -1,8 +1,6 @@
 name: Build and Push monolith to Google Cloud
 
-on:
-  push:
-    branches: [pull_request]
+on: [pull_request]
 
 env:
   GITHUB_SHA: ${{ github.sha }}
@@ -20,8 +18,8 @@ jobs:
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           version: '290.0.1'
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCLOUD_AUTH }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
       - name: Log in to GCR

--- a/.github/workflows/build-push-gcr.yml
+++ b/.github/workflows/build-push-gcr.yml
@@ -1,0 +1,44 @@
+name: Build and Push monolith to Google Cloud
+
+on:
+  push:
+    branches: [pull_request]
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  BRANCH: ${{ github.ref }}
+
+jobs:
+  build-n-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure gCloud credentials
+        id: gcloud-login
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCLOUD_AUTH }}
+          export_default_credentials: true
+
+      - name: Log in to GCR
+        run: |
+          gcloud auth configure-docker
+
+      - name: Build monolith
+        run: |
+          docker build --build-arg branch=$BRANCH --build-arg revision=$GITHUB_SHA --build-arg component=monolith \
+          -t gcr.io/cdssnc/covid-alert/server:$GITHUB_SHA \
+          -t gcr.io/cdssnc/covid-alert/server:latest \
+
+      - name: Push containers to GCR
+        run: |
+          docker push gcr.io/cdssnc/covid-alert/server:$GITHUB_SHA
+          docker push gcr.io/cdssnc/covid-alert/server:latest
+
+      - name: Logout of GCR
+        if: always()
+        run: docker logout ${{ steps.login-ecr-staging.outputs.registry }}


### PR DESCRIPTION
Part of #287. This add as a build action that pushes a monolith to Google Container Registry, which is public unlike AWS, where a Heroku PR review app in the mobile repo can deploy it.

Tested with the action running on branches vs. on master