### PR TITLE
Fix proto documentation

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -13,7 +13,7 @@ Some of the protocol is defined by [Google Protocol
 Buffers](https://developers.google.com/protocol-buffers). The file containing these definitions is
 in this repository at [covidshield.proto](covidshield.proto).
 
-The Diagnosis Server implements five main endpoints:
+The Diagnosis Server implements four main endpoints:
 
 
 * `/retrieve`: Fetch a set of Diagnosis Keys for a given UTC date number


### PR DESCRIPTION
Four are listed, not five.

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>
