### PR TITLE
Fix nil dereference if timestamp is not specified

### DIFF
--- a/pkg/server/upload.go
+++ b/pkg/server/upload.go
@@ -138,8 +138,8 @@ func (s *uploadServlet) upload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ts := time.Unix(upload.GetTimestamp().Seconds, 0)
-	if math.Abs(time.Since(ts).Seconds()) > 3600 {
+	ts := upload.GetTimestamp()
+	if ts == nil || math.Abs(time.Since(time.Unix(ts.Seconds, 0)).Seconds()) > 3600 {
 		requestError(
 			ctx, w, err, "invalid timestamp",
 			http.StatusBadRequest, uploadError(pb.EncryptedUploadResponse_INVALID_TIMESTAMP),


### PR DESCRIPTION
The protobuf definition for Upload shows timestamp as an optional field:

	optional google.protobuf.Timestamp timestamp = 1;

As such, the server will demarshal Uploads that lack a timestamp.
However, the server will later dereference the timestamp to access the
seconds count, reliably panicking the server and unexpectedly breaking
the connection to the client.

The panic is caught by safely.Recover, so the harm is minimized.
Further, executing this code path requires a COVID-19 diagnosis.
Nevertheless, the behaviour is still incorrect and should be hardened.

By explicitly checking if timestamp is non-nil, the panic is fixed and
INVALID_TIMESTAMP is returned as expected.

Signed-off-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>
