### PR TITLE
refactor(region code): hard code the region code

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,9 +21,8 @@ services:
       DB_PORT: 3306
       DATABASE_URL: "test:password@tcp(db)/test"
       ECDSA_KEY: 30770201010420a6885a310b694b7bb4ba985459de1e79446dddcd1247c62ece925402b362a110a00a06082a8648ce3d030107a1440342000403eb64f714c4b4ed394331c26c31b7ce7156d00fb28982ad2679a87eaa1a3869802fbeb1d7ee28002762921929c3f7603672d535fcac3d24d57afbb4e2d97f5a
-      KEY_CLAIM_TOKEN: thisisaverylongtoken=302
+      KEY_CLAIM_TOKEN: thisisaverylongtoken=TestProvince
       RETRIEVE_HMAC_KEY: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      METRIC_PROVIDER: stdout
     
   db:
     image: mysql:5.7

--- a/config.yaml
+++ b/config.yaml
@@ -30,3 +30,5 @@ corsAccessControlAllowOrigin: "*"
 # Feature flags
 disableCurrentDateCheckFeatureFlag: true
 enableEntirePeriodBundle: true
+
+regionCode: "302"

--- a/examples/new-key-claim/curl.sh
+++ b/examples/new-key-claim/curl.sh
@@ -6,7 +6,7 @@
 #   12345678
 #   $
 
-TOKEN="test"
+TOKEN="thisisaverylongtoken"
 URL_BASE="http://127.0.0.1:8000"
 
 curl -XPOST -H "Authorization: Bearer ${TOKEN}" "${URL_BASE}/new-key-claim"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,7 @@ type Constants struct {
 	CORSAccessControlAllowOrigin       string
 	DisableCurrentDateCheckFeatureFlag bool
 	EnableEntirePeriodBundle           bool
+	RegionCode                         string
 }
 
 var AppConstants Constants
@@ -62,4 +63,6 @@ func setDefaults() {
 	viper.SetDefault("corsAccessControlAllowOrigin", "*")
 	viper.SetDefault("disableCurrentDateCheckFeatureFlag", true)
 	viper.SetDefault("enableEntirePeriodBundle", false)
+	/// The MCC Region Code for Canada
+	viper.SetDefault("regionCode", "302")
 }

--- a/pkg/server/keyclaim.go
+++ b/pkg/server/keyclaim.go
@@ -17,8 +17,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const mccRegionCode = "302"
-
 func NewKeyClaimServlet(db persistence.Conn, keyClaimAuth keyclaim.Authenticator) srvutil.Servlet {
 	return &keyClaimServlet{db: db, auth: keyClaimAuth}
 }
@@ -72,7 +70,7 @@ func (s *keyClaimServlet) newKeyClaim(w http.ResponseWriter, r *http.Request) {
 		Also please note this hurts me to not go through the rest of the code to pull out the region code
 		I will open an issue to continue with this work.
 	*/
-	region = mccRegionCode
+	region = config.AppConstants.RegionCode
 
 	hashID := vars["hashID"]
 

--- a/pkg/server/keyclaim.go
+++ b/pkg/server/keyclaim.go
@@ -17,6 +17,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+const mccRegionCode = "302"
+
 func NewKeyClaimServlet(db persistence.Conn, keyClaimAuth keyclaim.Authenticator) srvutil.Servlet {
 	return &keyClaimServlet{db: db, auth: keyClaimAuth}
 }
@@ -61,6 +63,16 @@ func (s *keyClaimServlet) newKeyClaim(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
+
+	/*
+		Since the region that is being retrieved above is no longer the MCC code for canada
+		we want to override that with the actual value. The reason for this is that we are now
+		using the bearer token environment variable to store the name of the provice it's associated with
+
+		Also please note this hurts me to not go through the rest of the code to pull out the region code
+		I will open an issue to continue with this work.
+	*/
+	region = mccRegionCode
 
 	hashID := vars["hashID"]
 

--- a/pkg/server/retrieve.go
+++ b/pkg/server/retrieve.go
@@ -20,7 +20,6 @@ import (
 const (
 	numberOfDaysToServe = 14
 	hoursInDay          = 24
-	mccRegionCode       = "302"
 )
 
 func NewRetrieveServlet(db persistence.Conn, auth retrieval.Authenticator, signer retrieval.Signer) srvutil.Servlet {
@@ -65,7 +64,7 @@ func (s *retrieveServlet) retrieve(w http.ResponseWriter, r *http.Request) resul
 	As stated there I'm going to open an issue to continue this work instead of just
 	relying on the hardcoded value.
 	*/
-	region := mccRegionCode
+	region := config.AppConstants.RegionCode
 	if !s.auth.Authenticate(region, vars["day"], vars["auth"]) {
 		return s.fail(log(ctx, nil), w, "invalid auth parameter", "unauthorized", http.StatusUnauthorized)
 	}

--- a/pkg/server/retrieve.go
+++ b/pkg/server/retrieve.go
@@ -20,6 +20,7 @@ import (
 const (
 	numberOfDaysToServe = 14
 	hoursInDay          = 24
+	mccRegionCode       = "302"
 )
 
 func NewRetrieveServlet(db persistence.Conn, auth retrieval.Authenticator, signer retrieval.Signer) srvutil.Servlet {
@@ -59,7 +60,12 @@ func (s *retrieveServlet) retrieve(w http.ResponseWriter, r *http.Request) resul
 	ctx := r.Context()
 	vars := mux.Vars(r)
 
-	region := vars["region"]
+	/* Hardcode the region as 302 (Canada MCC)
+	You can see the reason for this in pkg/server/keyclaim.go
+	As stated there I'm going to open an issue to continue this work instead of just
+	relying on the hardcoded value.
+	*/
+	region := mccRegionCode
 	if !s.auth.Authenticate(region, vars["day"], vars["auth"]) {
 		return s.fail(log(ctx, nil), w, "invalid auth parameter", "unauthorized", http.StatusUnauthorized)
 	}


### PR DESCRIPTION
Instead of getting the region code from environment variables we are
hard coding it. This is so we can replace the region code in the env
vars with a province identifier that we can use for tracking events in
the system.

I'm pretty sure this is all we need to do in code to satisfy #290 the rest will have to come from the environment variables.