### PR TITLE
fix: return when access is unauthorized

### DIFF
--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -60,6 +60,7 @@ func (m *metricsServlet) handleEventRequest(w http.ResponseWriter, r *http.Reque
 	if err := authorizeRequest(r); err != nil {
 		log(ctx, err).Info("Unauthorized BasicAuth")
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
 	}
 
 	if r.Method != "GET" {
@@ -79,7 +80,7 @@ func (m *metricsServlet) getEvents(ctx context.Context, w http.ResponseWriter, r
 	_, err := time.Parse(ISODATE, startDateVal)
 	if err != nil {
 		log(ctx, err).Errorf("issue parsing %s", startDateVal)
-		http.Error(w, "error parsing start date", http.StatusBadRequest)
+		http.Error(w, "error parsing date", http.StatusBadRequest)
 		return
 	}
 

--- a/pkg/server/metrics_test.go
+++ b/pkg/server/metrics_test.go
@@ -2,20 +2,20 @@ package server
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	keyclaim "github.com/cds-snc/covid-alert-server/mocks/pkg/keyclaim"
 	persistence "github.com/cds-snc/covid-alert-server/mocks/pkg/persistence"
 	persistence2 "github.com/cds-snc/covid-alert-server/pkg/persistence"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
-
 
 func createRouter(db *persistence.Conn, auth *keyclaim.Authenticator) *mux.Router {
 
-	servlet  := NewMetricsServlet(db, auth)
+	servlet := NewMetricsServlet(db, auth)
 	router := Router()
 	servlet.RegisterRouting(router)
 
@@ -24,7 +24,7 @@ func createRouter(db *persistence.Conn, auth *keyclaim.Authenticator) *mux.Route
 }
 
 func createMocks() (*persistence.Conn, *keyclaim.Authenticator) {
-	return &persistence.Conn{}	, &keyclaim.Authenticator{}
+	return &persistence.Conn{}, &keyclaim.Authenticator{}
 }
 
 func TestNewMetricsServlet(t *testing.T) {
@@ -32,21 +32,103 @@ func TestNewMetricsServlet(t *testing.T) {
 	db, auth := createMocks()
 
 	expected := &metricsServlet{
-		db: db,
+		db:   db,
 		auth: auth,
 	}
 
 	assert.Equal(t, expected, NewMetricsServlet(db, auth), "should return a new metrics servlet")
 }
 
-func TestRegisterRoutingMetrics(t *testing.T) {
+func TestMetricsServlet_BasicAuth(t *testing.T) {
+	db, auth := createMocks()
+	router := createRouter(db, auth)
+
+	req, _ := http.NewRequest("GET", "/events/2020-01-01", nil)
+	req.Header.Set("Authorization", "Basic foo")
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+	assert.Equal(t, "unauthorized\n", string(resp.Body.Bytes()))
+}
+
+func TestMetricsServlet_InvalidDateFormat(t *testing.T) {
+	db, auth := createMocks()
+	router := createRouter(db, auth)
+
+	req, _ := http.NewRequest("GET", "/events/01-01-2001", nil)
+	req.Header.Set("Authorization", "Basic Zm9vOmJhcg==")
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+func TestMetricsServlet_ParseDate(t *testing.T) {
+	db, auth := createMocks()
+	router := createRouter(db, auth)
+
+	req, _ := http.NewRequest("GET", "/events/2001-32-01", nil)
+	req.Header.Set("Authorization", "Basic Zm9vOmJhcg==")
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Equal(t, "error parsing date\n", string(resp.Body.Bytes()))
+}
+
+func TestMetricsServlet_DisallowedMethods(t *testing.T) {
+
+	httpVerbs := []string{"POST", "PUT", "DELETE", "PATCH", "OPTIONS"}
+
+
+	db, auth := createMocks()
+	router := createRouter(db, auth)
+
+	for _, verb := range httpVerbs {
+		req, _ := http.NewRequest(verb, "/events/2001-01-01", nil)
+		req.Header.Set("Authorization", "Basic Zm9vOmJhcg==")
+
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusUnauthorized, resp.Code)
+		assert.Equal(t, "unauthorized\n", string(resp.Body.Bytes()))
+	}
+}
+
+func TestMetricsServlet_RegisterRoutingMetrics(t *testing.T) {
 
 	db, auth := createMocks()
 	router := createRouter(db, auth)
 
 	expectedPaths := GetPaths(router)
 
-	assert.Contains(t, expectedPaths,fmt.Sprintf("/events/{startDate:%s}", DATEFORMAT), "Should contain claimed-keys endpoint")
+	assert.Contains(t, expectedPaths, fmt.Sprintf("/events/{startDate:%s}", DATEFORMAT), "Should contain claimed-keys endpoint")
+}
+
+func TestMetricsServlet_DBError(t *testing.T) {
+
+	db, auth := createMocks()
+	router := createRouter(db, auth)
+
+	db.On("GetServerEvents", "2020-01-01").
+		Return(
+			nil,
+			fmt.Errorf("error"),
+		)
+
+	req, _ := http.NewRequest("GET", "/events/2020-01-01", nil)
+	req.Header.Set("Authorization", "Basic Zm9vOmJhcg==")
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Equal(t, "error retrieving events\n", string(resp.Body.Bytes()))
 }
 
 func TestMetricsServlet_ClaimedKeys(t *testing.T) {
@@ -54,23 +136,23 @@ func TestMetricsServlet_ClaimedKeys(t *testing.T) {
 	db, auth := createMocks()
 	router := createRouter(db, auth)
 
-		db.On("GetServerEvents",  "2020-01-01").
-			Return(
-				[]persistence2.Events{{
-					Identifier: "event",
-					Source: "foo",
-					Date: "bar",
-					Count: 1,
-				}},
-				nil,
-			)
+	db.On("GetServerEvents", "2020-01-01").
+		Return(
+			[]persistence2.Events{{
+				Identifier: "event",
+				Source:     "foo",
+				Date:       "bar",
+				Count:      1,
+			}},
+			nil,
+		)
 
-		req, _ := http.NewRequest("GET", "/events/2020-01-01", nil)
-		req.Header.Set("Authorization", "Basic Zm9vOmJhcg==")
+	req, _ := http.NewRequest("GET", "/events/2020-01-01", nil)
+	req.Header.Set("Authorization", "Basic Zm9vOmJhcg==")
 
-		resp := httptest.NewRecorder()
-		router.ServeHTTP(resp, req)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
 
-		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Equal(t, "[{\"source\":\"foo\",\"date\":\"bar\",\"count\":1,\"identifier\":\"event\"}]",string(resp.Body.Bytes()))
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, "[{\"source\":\"foo\",\"date\":\"bar\",\"count\":1,\"identifier\":\"event\"}]", string(resp.Body.Bytes()))
 }


### PR DESCRIPTION
Add a return after we fail authorization instead of continuing
Add some more tests to cover this case and a few others
