### PR TITLE
feat: switch test tools from retrieval to submission

### DIFF
--- a/cmd/key-retrieval/main.go
+++ b/cmd/key-retrieval/main.go
@@ -8,6 +8,5 @@ import (
 func main() {
 	cmd.RunAndWait(
 		app.NewBuilder().
-			WithTestTools().
 			WithRetrieval())
 }

--- a/cmd/key-submission/main.go
+++ b/cmd/key-submission/main.go
@@ -8,5 +8,6 @@ import (
 func main() {
 	cmd.RunAndWait(
 		app.NewBuilder().
+			WithTestTools().
 			WithSubmission())
 }


### PR DESCRIPTION
Since this is only going in staging submission is the better endpoint as it's safelisting is permissive in staging but restricted in prod this will provide an extra layer of protection in case it's enabled in prod. 
