### PR TITLE
ci: ignore license issues

### DIFF
--- a/.github/workflows/pr-test-ruby-ci.yml
+++ b/.github/workflows/pr-test-ruby-ci.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         go-version: '^1.14'
     - name: Install Protoc
-      uses: arduino/setup-protoc@7ad700d3b20e2a32b35d2c17fbdc463891608381
+      uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3
       with:
         version: '3.x'
     - name: Install protoc-gen-go

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           command: monitor
           args: --file=go.mod --org=exposurenotification
-            --project-name=covid-shield-server
+            --project-name=covid-alert-server

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -11,5 +11,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: monitor
-          args: --file=go.mod --org=exposurenotification
-            --project-name=covid-alert-server
+          args: --file=go.mod --org=exposurenotification --project-name=covid-alert-server

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.version: v1.14.0
+
+version: v1.14.0
+language-settings:
+ignore: 
+  snyk-vulnid:
+    - path to library using > seperator :
+      reason: 'text string'
+      expires: 'datetime string'
+patch: 

--- a/.snyk
+++ b/.snyk
@@ -4,10 +4,10 @@ version: v1.14.1
 ignore:
   'snyk:lic:golang:github.com:go-sql-driver:mysql:MPL-2.0':
     - '*':
-        reason: 'We don't modify any files in this dependency, and we don't distribute a binary'
+        reason: We don't modify any files in this dependency, and we do not distribute a binary
         expires: 2021-12-25T20:07:37.670Z
   'snyk:lic:golang:github.com:hashicorp:hcl:MPL-2.0':
     - '*':
-        reason: 'We don't modify any files in this dependency, and we don't distribute a binary'
+        reason: We don't modify any files in this dependency, and we do not distribute a binary
         expires: 2021-12-25T20:07:58.978Z
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -1,10 +1,13 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.version: v1.14.0
-
-version: v1.14.0
-language-settings:
-ignore: 
-  snyk-vulnid:
-    - path to library using > seperator :
-      reason: 'text string'
-      expires: 'datetime string'
-patch: 
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.14.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'snyk:lic:golang:github.com:go-sql-driver:mysql:MPL-2.0':
+    - '*':
+        reason: 'We don't modify any files in this dependency, and we don't distribute a binary'
+        expires: 2021-12-25T20:07:37.670Z
+  'snyk:lic:golang:github.com:hashicorp:hcl:MPL-2.0':
+    - '*':
+        reason: 'We don't modify any files in this dependency, and we don't distribute a binary'
+        expires: 2021-12-25T20:07:58.978Z
+patch: {}


### PR DESCRIPTION
Add a `.snyk` file to ignore the two MPL 2.0 License issues we don't have an issue with. 
Fix snyk workflow file. 

Closes #354 