### PR TITLE
ci: upgrade google-github-actions/setup-gcloud to 0.2.0

### DIFF
--- a/.github/workflows/build-push-gcr.yml
+++ b/.github/workflows/build-push-gcr.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Configure gCloud credentials
         id: gcloud-login
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@3025a7711899c25380bbef9ba82f89714de40c95
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
         with:
           version: '290.0.1'
           project_id: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
Fixes an issue with google-github-actions/setup-gcloud using deprecated commands in github
actions
See https://github.com/google-github-actions/setup-gcloud/issues/239
Fixes #357