### PR TITLE
Docs/sync labels

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -12,4 +12,4 @@ jobs:
       with: 
         GH_TOKEN: ${{ secrets.LABEL_TOKEN }}
       run: |
-        ./bin/sync-labels.sh
+        ./bin/sync-labels.sh apply

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,15 @@
+name: Sync Labels
+on: 
+  push:
+    paths:
+      - "labels.yml"
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: sync labels
+      with: 
+        GH_TOKEN: ${{ secrets.LABEL_TOKEN }}
+      run: |
+        ./bin/sync-labels.sh

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,10 +1,12 @@
 name: Sync Labels
 on: 
   push:
+    branches: [master]
     paths:
       - "labels.yml"
 jobs:
-  shellcheck:
+  sync-labels:
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/bin/sync-labels.sh
+++ b/bin/sync-labels.sh
@@ -1,14 +1,29 @@
 #!/bin/bash
-# github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server 
-# github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server-production-terraform
-# github-label-sync -a "$GH_TOKEN"  -l labels.yml -d cds-snc/covid-alert-server-staging-terraform
-# github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server-demo-terraform
-# github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server-metrics-extractor
-# github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server-metrics-extractor-creds
 
-github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server 
-github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server-production-terraform
-github-label-sync -a "$GH_TOKEN"  -l labels.yml cds-snc/covid-alert-server-staging-terraform
-github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server-demo-terraform
-github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server-metrics-extractor
-github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server-metrics-extractor-creds
+if [[ $# -eq 0 ]]; then 
+  echo "sync-labels dry-run"
+  echo "  view actions that will be taken"
+  echo "sync-labels apply"
+  echo "  apply changes to labels"
+  exit 1
+fi 
+
+if [[ $1 == "dry-run" ]]; then
+  github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server
+  github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server-production-terraform
+  github-label-sync -a "$GH_TOKEN"  -l labels.yml -d cds-snc/covid-alert-server-staging-terraform
+  github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server-demo-terraform
+  github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server-metrics-extractor
+  github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server-metrics-extractor-creds
+  exit 0
+fi
+
+if [[ $1 == "apply" ]]; then
+  github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server
+  github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server-production-terraform
+  github-label-sync -a "$GH_TOKEN"  -l labels.yml cds-snc/covid-alert-server-staging-terraform
+  github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server-demo-terraform
+  github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server-metrics-extractor
+  github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server-metrics-extractor-creds
+  exit 0
+fi

--- a/bin/sync-labels.sh
+++ b/bin/sync-labels.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server 
+# github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server-production-terraform
+# github-label-sync -a "$GH_TOKEN"  -l labels.yml -d cds-snc/covid-alert-server-staging-terraform
+# github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server-demo-terraform
+# github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server-metrics-extractor
+# github-label-sync -a "$GH_TOKEN" -l labels.yml -d cds-snc/covid-alert-server-metrics-extractor-creds
+
+github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server 
+github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server-production-terraform
+github-label-sync -a "$GH_TOKEN"  -l labels.yml cds-snc/covid-alert-server-staging-terraform
+github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server-demo-terraform
+github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server-metrics-extractor
+github-label-sync -a "$GH_TOKEN" -l labels.yml cds-snc/covid-alert-server-metrics-extractor-creds

--- a/labels.yml
+++ b/labels.yml
@@ -102,3 +102,8 @@
   description: Improvements to pipelines
   alias: []
   color: "19b3c1"
+
+- name: test label
+  description: testing CI
+  alias: []
+  color: "19b3c1"

--- a/labels.yml
+++ b/labels.yml
@@ -1,0 +1,104 @@
+- name: bug
+  description: Something isn't working
+  alias: []
+  color: "d73a4a"
+- name: documentation
+  description: Improvements or additions to documentation
+  alias: []
+  color: "0075ca"
+- name: duplicate
+  description: This issue or pull request already exists
+  alias: []
+  color: "cfd3d7"
+- name: enhancement
+  description: New feature or request
+  alias: []
+  color: "a2eeef"
+- name: good first issue
+  description: Good for newcomers
+  alias: []
+  color: "7057ff"
+- name: help wanted
+  description: Extra attention is needed
+  alias: []
+  color: "008672"
+- name: invalid
+  description: This doesn't seem right
+  alias: []
+  color: "e4e669"
+- name: question
+  description: Further information is requested
+  alias: []
+  color: "d876e3"
+- name: wontfix
+  description: This will not be worked on
+  alias: []
+  color: "ffffff"
+- name: security
+  description: 
+  alias: []
+  color: "aa2049"
+- name: infrastructure
+  description: 
+  alias: []
+  color: "2cc92e"
+- name: network
+  description: 
+  alias: []
+  color: "e4f99d"
+- name: launch blocker
+  description: 
+  alias: []
+  color: "ccf429"
+- name: privacy
+  description: 
+  alias: []
+  color: "d89eed"
+- name: CCCS
+  description: Canadian Centre for Cyber Security
+  alias: []
+  color: "ffccf3"
+- name: low priority
+  description: 
+  alias: []
+  color: "e5b712"
+- name: BBRY
+  description: Blackberry
+  alias: []
+  color: "aae1ff"
+- name: medium priority
+  description: 
+  alias: []
+  color: "e99695"
+- name: high priority
+  description: 
+  alias: []
+  color: "4a32c1"
+- name: on hold
+  description: 
+  alias: []
+  color: "c2e0c6"
+- name: S
+  description: 
+  alias: []
+  color: "636e72"
+- name: M
+  description: 
+  alias: []
+  color: "636e72"
+- name: L
+  description: 
+  alias: []
+  color: "636e72"
+- name: XL
+  description: 
+  alias: []
+  color: "636e72"
+- name: needs story definition
+  description: 
+  alias: []
+  color: "064760"
+- name: pipeline
+  description: Improvements to pipelines
+  alias: []
+  color: "19b3c1"


### PR DESCRIPTION
Syncs labels across the covid-alert-server pod projects with the contents labels.yml in this project. 

Uses https://github.com/Financial-Times/github-label-sync to sync between projects.

This PR also includes a test label to test the workflow I created to sync labels

Closes: #365 
