### PR TITLE
feat: track OTK lifetimes to the hour

### DIFF
--- a/pkg/persistence/main_test.go
+++ b/pkg/persistence/main_test.go
@@ -1,6 +1,8 @@
 package persistence
 
 import (
+	"database/sql"
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/cds-snc/covid-alert-server/pkg/config"
 	"github.com/cds-snc/covid-alert-server/pkg/keyclaim"
 	"os"
@@ -25,4 +27,9 @@ func TestMain(m *testing.M)  {
 	SetupLookup(keyclaim.NewAuthenticator())
 
 	os.Exit(m.Run())
+}
+
+func createNewSqlMock() (*sql.DB, sqlmock.Sqlmock) {
+	db, mock, _ := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	return db, mock
 }

--- a/pkg/persistence/migrator.go
+++ b/pkg/persistence/migrator.go
@@ -120,6 +120,20 @@ CREATE TABLE IF NOT EXISTS tek_upload_count (
 	INDEX (date)
 )`,
 		},
+	},{
+		id: "9",
+		statements: []string{
+			`
+CREATE TABLE IF NOT EXISTS otk_life_duration (
+	originator	VARCHAR(32) 	NOT NULL,
+	hours		INT				NOT NULL,
+	date		DATE			NOT NULL,
+	count		INT				UNSIGNED NOT NULL DEFAULT 0,
+	INDEX (originator),
+	INDEX (date),
+	UNIQUE KEY originator_date(originator, date)
+)`,
+		},
 	},
 }
 

--- a/pkg/persistence/otk_duration.go
+++ b/pkg/persistence/otk_duration.go
@@ -1,0 +1,33 @@
+package persistence
+
+import(
+	"database/sql"
+	"math"
+	"time"
+)
+
+// OtkDuration duration of time an OTK is live sorted by originator
+// Originator where the OTK was generated
+// Duration the number of hours that the otk was live
+type OtkDuration struct {
+	Originator string
+	Duration time.Duration
+}
+
+func saveOtkDuration(db *sql.DB, otkDuration OtkDuration) error {
+
+	hoursLive := otkDuration.Duration.Hours()
+	hours := math.Ceil(hoursLive)
+
+	originator := translateToken(otkDuration.Originator)
+
+	if _, err := db.Exec(`
+		INSERT INTO otk_life_duration
+		(originator, hours, date, count)
+		VALUES(?, ?, ?, 1) ON DUPLICATE KEY UPDATE count = count + 1`,
+		originator, hours, time.Now().Format("2006-01-02")); err != nil{
+		return err
+	}
+	return nil
+}
+

--- a/pkg/persistence/otk_duration_test.go
+++ b/pkg/persistence/otk_duration_test.go
@@ -1,0 +1,46 @@
+package persistence
+
+import (
+	"github.com/DATA-DOG/go-sqlmock"
+	"testing"
+	"time"
+)
+
+func setupOtkDurationMock(mock sqlmock.Sqlmock, originator string, duration int) {
+	mock.ExpectExec(`
+		INSERT INTO otk_life_duration
+		(originator, hours, date, count)
+		VALUES(?, ?, ?, 1) ON DUPLICATE KEY UPDATE count = count + 1`).
+		WithArgs( originator, duration, AnyType{}).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+}
+
+func Test_roundToNearestHourLessThan1Hour(t *testing.T){
+	db, mock := createNewSqlMock()
+	defer db.Close()
+
+	setupOtkDurationMock(mock, "foo", 1)
+
+	d, _ := time.ParseDuration("30m")
+	od := OtkDuration{
+		"foo",
+		d,
+	}
+
+	saveOtkDuration(db, od)
+}
+
+func Test_roundToNearestHourSixHours(t *testing.T){
+	db, mock := createNewSqlMock()
+	defer db.Close()
+
+	setupOtkDurationMock(mock, "foo", 1)
+
+	d, _ := time.ParseDuration("5h15m")
+	od := OtkDuration{
+		"foo",
+		d,
+	}
+
+	saveOtkDuration(db, od)
+}


### PR DESCRIPTION
Add a new table in the database to store aggregate OTK lifetimes by day,
province and hours live.

Related to #308 
