### PR TITLE
fix: drop old duration table replace with new one

### DIFF
--- a/pkg/persistence/migrator.go
+++ b/pkg/persistence/migrator.go
@@ -134,6 +134,21 @@ CREATE TABLE IF NOT EXISTS otk_life_duration (
 	UNIQUE KEY originator_date(originator, date)
 )`,
 		},
+	},{
+		id: "10",
+		statements: []string{`
+DROP TABLE otk_life_duration
+`,`
+CREATE TABLE IF NOT EXISTS otk_life_duration (
+	originator	VARCHAR(32) 	NOT NULL,
+	hours		INT				NOT NULL,
+	date		DATE			NOT NULL,
+	count		INT				UNSIGNED NOT NULL DEFAULT 0,
+	INDEX (originator),
+	INDEX (hours),
+	UNIQUE KEY originator_hours(originator, hours)
+)`,
+		},
 	},
 }
 


### PR DESCRIPTION
fixes #428 

## Description of what your PR accomplishes:

This PR adds a migration that will drop the otk_life_durations table and create a new one in it's place that uses the `originator` and `hours`  as a unique key constraint on the table instead of `originator` and `duration`

## Why this approach? Any notable design decisions?

As the data we previously captured is essentially worthless due to this bug and we cannot re-generate the actual metrics dropping the table and recreating it through a migration is the easiest solution to this bug. 

## Anything the reviewers should focus on? Any discussion points?

Make sure that migration works.
