### PR TITLE
feat: make severity optional in upload and default to 0 on download

### DIFF
--- a/pkg/persistence/migrator.go
+++ b/pkg/persistence/migrator.go
@@ -167,6 +167,11 @@ CREATE TABLE IF NOT EXISTS qr_outbreak_events (
 		statements: []string{
 			`ALTER TABLE qr_outbreak_events ADD COLUMN severity SMALLINT UNSIGNED`,
 		},
+	}, {
+		id: "13",
+		statements: []string{
+			`ALTER TABLE qr_outbreak_events ALTER severity SET DEFAULT 0`,
+		},
 	},
 }
 

--- a/test/qr_retrieval_test.rb
+++ b/test/qr_retrieval_test.rb
@@ -90,6 +90,28 @@ class QRRetrieveTest < MiniTest::Test
     assert_locations(export, locations, date_number: dn)
   end
 
+  def test_missing_severity
+    start_time = time_in_date('10:00', today_utc.prev_day(8))
+    end_time = time_in_date('12:00', today_utc.prev_day(8))
+    @dbconn.prepare(<<~SQL)
+      INSERT INTO qr_outbreak_events
+      (location_id, originator, start_time, end_time, created)
+      VALUES (?, ?, ?, ?, ?)
+    SQL
+    .execute("ABCDEFGH", "ON", start_time.to_i, end_time.to_i, time_in_date('07:00', yesterday_utc))
+
+    dn = current_date_number - 1
+
+    resp = get_qr_date(dn)
+    export = assert_happy_zip_response(resp)
+    locations = [location(
+        start_time: start_time,
+        end_time: end_time,
+        severity: 0
+    )]
+    assert_locations(export, locations, date_number: dn)
+  end
+
   def test_all_keys
     start_time = time_in_date('10:00', today_utc.prev_day(8))
     end_time = time_in_date('12:00', today_utc.prev_day(8))

--- a/test/qr_submission_test.rb
+++ b/test/qr_submission_test.rb
@@ -62,6 +62,14 @@ class NewOutbreakEventTest < MiniTest::Test
     end
     assert_result(resp, 400, :PERIOD_INVALID)
 
+    # No severity
+    resp = @sub_conn.post do |req|
+      req.url('/qr/new-event')
+      req.headers['Authorization'] = 'Bearer first-very-long-token'
+      req.body = Covidshield::OutbreakEvent.new(start_time: Time.now,  end_time: Time.now+1, location_id: "ABCDEFGH").to_proto
+    end
+    assert_result(resp, 200, :NONE)
+
     # valid response
     resp = @sub_conn.post do |req|
       req.url('/qr/new-event')


### PR DESCRIPTION
This PR makes the severity of the and outbreak optional in that it does not check for a value on upload and defaults to `0` when the outbreak is downloaded. This way, regardless of the input on the portal end, the app will have a consistent model in evaluating the data. 