### PR TITLE
fix: monolith CI action

### DIFF
--- a/.github/workflows/build-push-monolith.yml
+++ b/.github/workflows/build-push-monolith.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip -q awscliv2.zip
-          sudo ./aws/install
+          sudo ./aws/install --update
           aws --version
 
       - name: AWS auth with ECR


### PR DESCRIPTION
GitHub Actions recently started using Ubuntu 20.04 when we specify we want to use the ubuntu-latest image. The AWS CLI v2 is already installed in this new version, see actions/virtual-environments#1816

Add the --update flag to install the latest available version and override the default one GitHub gives us.

Similar to https://github.com/cds-snc/notification-admin/pull/918