### PR TITLE
chore: bump `bin/stuff-database` Python dependencies

### DIFF
--- a/bin/stuff-database/requirements.txt
+++ b/bin/stuff-database/requirements.txt
@@ -1,2 +1,3 @@
 pynacl==1.4.0
-requests==2.23.0
+requests==2.26.0
+urllib3==1.26.7


### PR DESCRIPTION
# Summary
This fixes a [security vulnerability](https://app.snyk.io/vuln/SNYK-PYTHON-URLLIB3-1533435) that exists with `urllib3 < 1.26.5`.

This should have no impact on the server as it is only a standalone utility that is being updated.