### PR TITLE
feat: move DB write actions to submission server

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -11,4 +11,4 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: monitor
-          args: --file=go.mod --org=exposurenotification --project-name=covid-alert-server
+          args: --file=go.mod --org=cds-snc --project-name=covid-alert-server

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -61,8 +61,11 @@ func checkEnvironmentVariable(key string) {
 }
 
 func (a *AppBuilder) WithSubmission() *AppBuilder {
+	migrateDB(DatabaseURL()) // This is a bit of a weird place for this but it works for now.
 
 	a.defaultServerPort = config.AppConstants.DefaultSubmissionServerPort
+
+	a.components = append(a.components, newExpirationWorker(a.database))
 
 	a.servlets = append(a.servlets, server.NewUploadServlet(a.database))
 	a.servlets = append(a.servlets, server.NewKeyClaimServlet(a.database, lookup))
@@ -72,11 +75,8 @@ func (a *AppBuilder) WithSubmission() *AppBuilder {
 }
 
 func (a *AppBuilder) WithRetrieval() *AppBuilder {
-	migrateDB(DatabaseURL()) // This is a bit of a weird place for this but it works for now.
 
 	a.defaultServerPort = config.AppConstants.DefaultRetrievalServerPort
-
-	a.components = append(a.components, newExpirationWorker(a.database))
 
 	a.servlets = append(a.servlets, server.NewRetrieveServlet(a.database, retrieval.NewAuthenticator(), retrieval.NewSigner()))
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -61,12 +61,11 @@ func checkEnvironmentVariable(key string) {
 }
 
 func (a *AppBuilder) WithSubmission() *AppBuilder {
-	migrateDB(DatabaseURL()) // This is a bit of a weird place for this but it works for now.
 
+	migrateDB(DatabaseURL()) // This is a bit of a weird place for this but it works for now.
 	a.defaultServerPort = config.AppConstants.DefaultSubmissionServerPort
 
 	a.components = append(a.components, newExpirationWorker(a.database))
-
 	a.servlets = append(a.servlets, server.NewUploadServlet(a.database))
 	a.servlets = append(a.servlets, server.NewKeyClaimServlet(a.database, lookup))
 	a.servlets = append(a.servlets, server.NewOutbreakEventServlet(a.database, lookup))

--- a/test/expiration_worker_test.rb
+++ b/test/expiration_worker_test.rb
@@ -69,7 +69,7 @@ class ExpirationWorkerTest < MiniTest::Test
   def expire
     # this doesn't yield until the server returns ok, which doesn't happen
     # until after the first run of the expiration worker.
-    Helper.with_server(KEY_RETRIEVAL_SERVER, RETRIEVAL_SERVER_ADDR) { }
+    Helper.with_server(KEY_SUBMISSION_SERVER, SUBMISSION_SERVER_ADDR) { }
   end
 
   def expire_and_assert(encryption: nil, diagnosis: nil)

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -208,8 +208,8 @@ module Helper
     end
 
     def with_servers(&block)
-      with_server(KEY_RETRIEVAL_SERVER, RETRIEVAL_SERVER_ADDR) do |ret_conn|
-        with_server(KEY_SUBMISSION_SERVER, SUBMISSION_SERVER_ADDR) do |sub_conn|
+      with_server(KEY_SUBMISSION_SERVER, SUBMISSION_SERVER_ADDR) do |sub_conn|
+        with_server(KEY_RETRIEVAL_SERVER, RETRIEVAL_SERVER_ADDR) do |ret_conn|
           block.call(sub_conn, ret_conn)
         end
       end


### PR DESCRIPTION
Move the database migration work and the expiration worker from the retrieval server to the submission server.

We are doing this so that we can have the retrieval server use the readonly end point for RDS which should reduce DB load on the write instance of RDS.
