### PR TITLE
chore: remove QR code servlets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PROTO_RB    := $(patsubst proto/%.proto,test/lib/protocol/%_pb.rb,$(PROTO_FILES)
 RPC_RB      := $(patsubst proto/%.proto,test/lib/protocol/%_services_pb.rb,$(PROTO_FILES_WITH_RPC))
 
 GOFILES     := $(shell find . -type f -name '*.go')
-TEST_FILES  := $(shell find test -type f -name '*_test.rb')
+TEST_FILES  := $(shell find test -type f -name '*_test.rb' -not -name 'qr*_test.rb')
 
 RELEASE_BUILDS := $(patsubst %,build/release/%,$(CMDS))
 DEBUG_BUILDS   := $(patsubst %,build/debug/%,$(CMDS))

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -68,7 +68,6 @@ func (a *AppBuilder) WithSubmission() *AppBuilder {
 	a.components = append(a.components, newExpirationWorker(a.database))
 	a.servlets = append(a.servlets, server.NewUploadServlet(a.database))
 	a.servlets = append(a.servlets, server.NewKeyClaimServlet(a.database, lookup))
-	a.servlets = append(a.servlets, server.NewOutbreakEventServlet(a.database, lookup))
 
 	return a
 }
@@ -83,8 +82,6 @@ func (a *AppBuilder) WithRetrieval() *AppBuilder {
 	checkEnvironmentVariable("METRICS_USERNAME")
 	checkEnvironmentVariable("METRICS_PASSWORD")
 	a.servlets = append(a.servlets, server.NewMetricsServlet(a.database, lookup))
-
-	a.servlets = append(a.servlets, server.NewQrRetrieveServlet(a.database, retrieval.NewAuthenticator(), retrieval.NewSigner()))
 
 	return a
 }


### PR DESCRIPTION
# Summary
Remove the QR code servlets from the key submission and retrieval servers.

Also removes the QR code tests from the `make test` command.